### PR TITLE
Fixed a corner case for the GetTemplateID helper func

### DIFF
--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -1292,12 +1292,13 @@ func (s *TemplateService) NewListTemplatesParams(templatefilter string) *ListTem
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateID(name string, templatefilter string) (string, error) {
+func (s *TemplateService) GetTemplateID(name string, templatefilter string, zoneid string) (string, error) {
 	p := &ListTemplatesParams{}
 	p.p = make(map[string]interface{})
 
 	p.p["name"] = name
 	p.p["templatefilter"] = templatefilter
+	p.p["zoneid"] = zoneid
 
 	l, err := s.ListTemplates(p)
 	if err != nil {
@@ -1323,8 +1324,8 @@ func (s *TemplateService) GetTemplateID(name string, templatefilter string) (str
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateByName(name string, templatefilter string) (*Template, int, error) {
-	id, err := s.GetTemplateID(name, templatefilter)
+func (s *TemplateService) GetTemplateByName(name string, templatefilter string, zoneid string) (*Template, int, error) {
+	id, err := s.GetTemplateID(name, templatefilter, zoneid)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/cloudstack43/TemplateService.go
+++ b/cloudstack43/TemplateService.go
@@ -1276,12 +1276,13 @@ func (s *TemplateService) NewListTemplatesParams(templatefilter string) *ListTem
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateID(name string, templatefilter string) (string, error) {
+func (s *TemplateService) GetTemplateID(name string, templatefilter string, zoneid string) (string, error) {
 	p := &ListTemplatesParams{}
 	p.p = make(map[string]interface{})
 
 	p.p["name"] = name
 	p.p["templatefilter"] = templatefilter
+	p.p["zoneid"] = zoneid
 
 	l, err := s.ListTemplates(p)
 	if err != nil {
@@ -1307,8 +1308,8 @@ func (s *TemplateService) GetTemplateID(name string, templatefilter string) (str
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateByName(name string, templatefilter string) (*Template, int, error) {
-	id, err := s.GetTemplateID(name, templatefilter)
+func (s *TemplateService) GetTemplateByName(name string, templatefilter string, zoneid string) (*Template, int, error) {
+	id, err := s.GetTemplateID(name, templatefilter, zoneid)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/cloudstack44/NetworkService.go
+++ b/cloudstack44/NetworkService.go
@@ -258,9 +258,6 @@ func (p *CreateNetworkParams) toURLValues() url.Values {
 	if v, found := p.p["vlan"]; found {
 		u.Set("vlan", v.(string))
 	}
-	if v, found := p.p["vlan"]; found {
-		u.Set("vlan", v.(string))
-	}
 	if v, found := p.p["vpcid"]; found {
 		u.Set("vpcid", v.(string))
 	}

--- a/cloudstack44/TemplateService.go
+++ b/cloudstack44/TemplateService.go
@@ -1292,12 +1292,13 @@ func (s *TemplateService) NewListTemplatesParams(templatefilter string) *ListTem
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateID(name string, templatefilter string) (string, error) {
+func (s *TemplateService) GetTemplateID(name string, templatefilter string, zoneid string) (string, error) {
 	p := &ListTemplatesParams{}
 	p.p = make(map[string]interface{})
 
 	p.p["name"] = name
 	p.p["templatefilter"] = templatefilter
+	p.p["zoneid"] = zoneid
 
 	l, err := s.ListTemplates(p)
 	if err != nil {
@@ -1323,8 +1324,8 @@ func (s *TemplateService) GetTemplateID(name string, templatefilter string) (str
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateByName(name string, templatefilter string) (*Template, int, error) {
-	id, err := s.GetTemplateID(name, templatefilter)
+func (s *TemplateService) GetTemplateByName(name string, templatefilter string, zoneid string) (*Template, int, error) {
+	id, err := s.GetTemplateID(name, templatefilter, zoneid)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -653,6 +653,10 @@ func (s *service) generateHelperFuncs(a *API) {
 					p("%s %s, ", s.parseParamName(ap.Name), mapType(ap.Type))
 				}
 			}
+			// Add an addition (needed) parameter for the GetTemplateId helper function
+			if parseSingular(ln) == "Template" {
+				p("zoneid string, ")
+			}
 			pn(") (string, error) {")
 
 			// Generate the function body
@@ -664,6 +668,10 @@ func (s *service) generateHelperFuncs(a *API) {
 				if ap.Required {
 					pn("	p.p[\"%s\"] = %s", s.parseParamName(ap.Name), s.parseParamName(ap.Name))
 				}
+			}
+			// Assign the additional parameter for the GetTemplateId helper function
+			if parseSingular(ln) == "Template" {
+				pn("	p.p[\"zoneid\"] = zoneid")
 			}
 			pn("")
 			pn("	l, err := s.List%s(p)", ln)
@@ -699,6 +707,10 @@ func (s *service) generateHelperFuncs(a *API) {
 						p("%s %s, ", s.parseParamName(ap.Name), mapType(ap.Type))
 					}
 				}
+				// Add an addition (needed) parameter for the GetTemplateId helper function
+				if parseSingular(ln) == "Template" {
+					p("zoneid string, ")
+				}
 				pn(") (*%s, int, error) {", parseSingular(ln))
 
 				// Generate the function body
@@ -707,6 +719,10 @@ func (s *service) generateHelperFuncs(a *API) {
 					if ap.Required {
 						p("%s, ", s.parseParamName(ap.Name))
 					}
+				}
+				// Assign the additional parameter for the GetTemplateId helper function
+				if parseSingular(ln) == "Template" {
+					p("zoneid")
 				}
 				pn(")")
 				pn("  if err != nil {")


### PR DESCRIPTION
Without the zoneid it’s possible that you get the UUID of a template with the same name, but for a different zone as the one where you currently need the template for.