### PR TITLE
Fix for parsing create/register SSH keypair responses 

### DIFF
--- a/cloudstack43/SSHService.go
+++ b/cloudstack43/SSHService.go
@@ -357,6 +357,10 @@ func (s *SSHService) RegisterSSHKeyPair(p *RegisterSSHKeyPairParams) (*RegisterS
 		return nil, err
 	}
 
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
 	var r RegisterSSHKeyPairResponse
 	if err := json.Unmarshal(resp, &r); err != nil {
 		return nil, err
@@ -438,6 +442,10 @@ func (s *SSHService) NewCreateSSHKeyPairParams(name string) *CreateSSHKeyPairPar
 func (s *SSHService) CreateSSHKeyPair(p *CreateSSHKeyPairParams) (*CreateSSHKeyPairResponse, error) {
 	resp, err := s.cs.newRequest("createSSHKeyPair", p.toURLValues())
 	if err != nil {
+		return nil, err
+	}
+
+	if resp, err = getRawValue(resp); err != nil {
 		return nil, err
 	}
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -849,7 +849,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 	pn("		return nil, err")
 	pn("	}")
 	pn("")
-	if n == "CreateNetwork" {
+	if n == "CreateNetwork" || n == "CreateSSHKeyPair" || n == "RegisterSSHKeyPair" {
 		pn("	if resp, err = getRawValue(resp); err != nil {")
 		pn("		return nil, err")
 		pn("	}")


### PR DESCRIPTION
I've made this simple fix for parsing the responses of these SSH keypair actions. As with createNetwork, the responses have the following format:

{ "registersshkeypairresponse" :  { "keypair" : {"name":"test-key","fingerprint":"f6:26:99:89:b8:d3:58:96:95:1b:88:ba:03:5c:50:51"} }  }

{ "createsshkeypairresponse" :  { "keypair" : {"privatekey":"PRIVATEKEY"} }  }

Therefore, we must use the getRawValue function before unmarshalling. I have been using this fix with a new Terraform resource (on my sshkey branch) which I am raising another PR for. There are some tests in there also in case you want to check it out.

Let me know what you think and also if this works ok for Cloudstack 4.4?