### PR TITLE
updateVirtualMachine should use POST

### DIFF
--- a/cloudstack43/cloudstack.go
+++ b/cloudstack43/cloudstack.go
@@ -282,7 +282,7 @@ func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawM
 
 	var err error
 	var resp *http.Response
-	if api == "deployVirtualMachine" {
+	if api == "deployVirtualMachine" || api == "updateVirtualMachine" {
 		// The deployVirtualMachine API should be called using a POST call
 		// so we don't have to worry about the userdata size
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -369,7 +369,7 @@ func (as *allServices) GeneralCode() ([]byte, error) {
 	pn("")
 	pn("	var err error")
 	pn("	var resp *http.Response")
-	pn("	if api == \"deployVirtualMachine\" {")
+	pn("	if api == \"deployVirtualMachine\" || api == \"updateVirtualMachine\" {")
 	pn("		// The deployVirtualMachine API should be called using a POST call")
 	pn("  	// so we don't have to worry about the userdata size")
 	pn("")


### PR DESCRIPTION
Simple change here - we can also send userdata with this call so we must use POST to allow a large userdata to be sent