### PR TITLE
Capitalise the k in apiKey, as some api handlers require this

### DIFF
--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -261,7 +261,7 @@ func (cs *CloudStackClient) GetAsyncJobResult(jobid string, timeout int64) (b js
 // no error occured. If the API returns an error the result will be nil and the HTTP error code and CS
 // error details. If a processing (code) error occurs the result will be nil and the generated error
 func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {
-	params.Set("apikey", cs.apiKey)
+	params.Set("apiKey", cs.apiKey)
 	params.Set("command", api)
 	params.Set("response", "json")
 

--- a/cloudstack43/cloudstack.go
+++ b/cloudstack43/cloudstack.go
@@ -267,7 +267,7 @@ func (cs *CloudStackClient) GetAsyncJobResult(jobid string, timeout int64) (b js
 // no error occured. If the API returns an error the result will be nil and the HTTP error code and CS
 // error details. If a processing (code) error occurs the result will be nil and the generated error
 func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {
-	params.Set("apikey", cs.apiKey)
+	params.Set("apiKey", cs.apiKey)
 	params.Set("command", api)
 	params.Set("response", "json")
 

--- a/cloudstack44/cloudstack.go
+++ b/cloudstack44/cloudstack.go
@@ -261,7 +261,7 @@ func (cs *CloudStackClient) GetAsyncJobResult(jobid string, timeout int64) (b js
 // no error occured. If the API returns an error the result will be nil and the HTTP error code and CS
 // error details. If a processing (code) error occurs the result will be nil and the generated error
 func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {
-	params.Set("apikey", cs.apiKey)
+	params.Set("apiKey", cs.apiKey)
 	params.Set("command", api)
 	params.Set("response", "json")
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -352,7 +352,7 @@ func (as *allServices) GeneralCode() ([]byte, error) {
 	pn("// no error occured. If the API returns an error the result will be nil and the HTTP error code and CS")
 	pn("// error details. If a processing (code) error occurs the result will be nil and the generated error")
 	pn("func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {")
-	pn("  params.Set(\"apikey\", cs.apiKey)")
+	pn("  params.Set(\"apiKey\", cs.apiKey)")
 	pn("  params.Set(\"command\", api)")
 	pn("  params.Set(\"response\", \"json\")")
 	pn("")


### PR DESCRIPTION
The documentation shows `apiKey`, and I was receiving errors specifically from the `listNetworks` api when `key` is lowercase.

Have tested this via terraform, and it works with the capital `k`.