### PR TITLE
Specify proper key/value names for serviceproviderlist

### DIFF
--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -91,8 +91,8 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack43/NetworkOfferingService.go
+++ b/cloudstack43/NetworkOfferingService.go
@@ -91,8 +91,8 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack44/NetworkOfferingService.go
+++ b/cloudstack44/NetworkOfferingService.go
@@ -91,8 +91,8 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}


### PR DESCRIPTION
Change the behaviour of serviceproviderlist on networkoffering so the proper key/value names are passed. Originally a request looks like this:

```
http://cloudstackhost:8080/client/api?
apiKey=REDACTED
command=createNetworkOffering
displaytext=networkoffering_test2
guestiptype=isolated
name=networkoffering_test2
response=json
serviceproviderlist[0].key=userdata
serviceproviderlist[0].value=VirtualRouter
serviceproviderlist[1].key=dhcp
serviceproviderlist[1].value=VirtualRouter
supportedservices=userdata%2Cdhcp
traffictype=GUEST
```
and fails with:

```
CloudStack API error 431 (CSExceptionErrorCode: 4350): Service null is not enabled for the network offering, can't add a provider to it
```

Whereas cloudmonkey passes the proper values:

```
http://cloudstackhost:8080/client/api?
apiKey=REDACTED
command=createNetworkOffering
displaytext=networkoffering_test2
guestiptype=isolated
name=networkoffering_test2
response=json
serviceproviderlist[0].provider=VirtualRouter
serviceproviderlist[0].service=userdata
serviceproviderlist[1].provider=VirtualRouter
serviceproviderlist[1].service=dhcp
supportedservices=userdata%2Cdhcp
traffictype=GUEST
```