### PR TITLE
Add support for custom key/value names for specific api calls

### DIFF
--- a/generate/apiv43.go
+++ b/generate/apiv43.go
@@ -23491,7 +23491,7 @@ const v43api = `{
 	     "length": 255,
 	     "name": "serviceproviderlist",
 	     "required": false,
-	     "type": "map"
+	     "type": "map_service-provider"
 	   }
 	 ],
 	 "related": "listVPCOfferings",
@@ -62127,7 +62127,7 @@ const v43api = `{
 	     "length": 255,
 	     "name": "serviceproviderlist",
 	     "required": false,
-	     "type": "map"
+	     "type": "map_service-provider"
 	   },
 	   {
 	     "description": "desired service capabilities as part of network offering",

--- a/generate/apiv44.go
+++ b/generate/apiv44.go
@@ -24463,7 +24463,7 @@ const v44api = `{
              "length": 255,
              "name": "serviceproviderlist",
              "required": false,
-             "type": "map"
+             "type": "map_service-provider"
            },
            {
              "description": "the name of the vpc offering",
@@ -65265,7 +65265,7 @@ const v44api = `{
              "length": 255,
              "name": "serviceproviderlist",
              "required": false,
-             "type": "map"
+             "type": "map_service-provider"
            },
            {
              "description": "if true keepalive will be turned on in the loadbalancer. At the time of writing this has only an effect on haproxy; the mode http and httpclose options are unset in the haproxy conf file.",


### PR DESCRIPTION
I don't know how clean this is, but it should be able to be grown for other types of different key/value systems. `generateConvertCode` can probably done nicer without so much repeated lines. Let me know if this is a solution, or I can create an issue so you can work on this whenever is a good time for you.