### PR TITLE
Introduce a way to have specific key/value names

### DIFF
--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -91,8 +91,8 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -1350,8 +1350,8 @@ func (p *CreateVPCOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack43/NetworkOfferingService.go
+++ b/cloudstack43/NetworkOfferingService.go
@@ -91,8 +91,8 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack43/VPCService.go
+++ b/cloudstack43/VPCService.go
@@ -1276,8 +1276,8 @@ func (p *CreateVPCOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack44/NetworkOfferingService.go
+++ b/cloudstack44/NetworkOfferingService.go
@@ -91,8 +91,8 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/cloudstack44/VPCService.go
+++ b/cloudstack44/VPCService.go
@@ -1350,8 +1350,8 @@ func (p *CreateVPCOfferingParams) toURLValues() url.Values {
 	if v, found := p.p["serviceproviderlist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].value", i), vv)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
 			i++
 		}
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -600,8 +600,14 @@ func (s *service) generateConvertCode(name, typ string) {
 	case "map[string]string":
 		pn("i := 0")
 		pn("for k, vv := range v.(map[string]string) {")
-		pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", n)
-		pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), vv)", n)
+		switch name {
+		case "serviceproviderlist":
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].service\", i), k)", n)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].provider\", i), vv)", n)
+		default:
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", n)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), vv)", n)
+		}
 		pn("	i++")
 		pn("}")
 	}
@@ -966,7 +972,8 @@ func (s *service) generateNewAPICallFunc(a *API) {
 	pn("		return nil, err")
 	pn("	}")
 	pn("")
-	if n == "CreateNetwork" || n == "CreateServiceOffering" || n == "CreateSSHKeyPair" || n == "RegisterSSHKeyPair" {
+	switch n {
+	case "CreateNetwork", "CreateServiceOffering", "CreateSSHKeyPair", "RegisterSSHKeyPair":
 		pn("	if resp, err = getRawValue(resp); err != nil {")
 		pn("		return nil, err")
 		pn("	}")


### PR DESCRIPTION
This is an alternative solution for PR #47.

By using this approach we don’t have to make any changes to the raw output generated by the `listApis` API call (which is saved in the `v43.go` and `v44.go` files).

So when we now want to generate code based on a new version, we only have to paste the output of the `listApis` call info a new `vxx.go` file and were good to go, without having to manually alter the file.

Next to all that’ it simple feels a little cleaner and more robust :wink: