### PR TITLE
Fix issue #54

### DIFF
--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -2008,12 +2008,12 @@ func (s *LoadBalancerService) ListLoadBalancerRuleInstances(p *ListLoadBalancerR
 
 type ListLoadBalancerRuleInstancesResponse struct {
 	Count                     int                         `json:"count"`
-	LoadBalancerRuleInstances []*LoadBalancerRuleInstance `json:"loadbalancerruleinstance"`
+	LoadBalancerRuleInstances []*LoadBalancerRuleInstance `json:"lbrulevmidip"`
 }
 
 type LoadBalancerRuleInstance struct {
-	Lbvmipaddresses          []string `json:"lbvmipaddresses,omitempty"`
-	Loadbalancerruleinstance string   `json:"loadbalancerruleinstance,omitempty"`
+	Lbvmipaddresses          []string        `json:"lbvmipaddresses,omitempty"`
+	Loadbalancerruleinstance *VirtualMachine `json:"loadbalancerruleinstance,omitempty"`
 }
 
 type UpdateLoadBalancerRuleParams struct {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1081,6 +1081,8 @@ func (s *service) generateResponseType(a *API) {
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "asyncjobs")
 		case "listEgressFirewallRules":
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "firewallrule")
+		case "listLoadBalancerRuleInstances":
+			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "lbrulevmidip")
 		case "registerTemplate":
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "template")
 		default:
@@ -1226,6 +1228,9 @@ func mapType(t string) string {
 		return "map[string]string"
 	case "responseobject":
 		return "json.RawMessage"
+	case "uservmresponse":
+		// This is a really specific abnormaly of the API
+		return "*VirtualMachine"
 	default:
 		return "string"
 	}


### PR DESCRIPTION
This fixes issue #54 by adding some specific tweaks needed to handle
the `listLoadBalancerRuleInstances` response correctly.

Unfortunately the CloudStack API has a few strange corner
cases/inconsistencies that requires specific handling of certain calls.