### PR TITLE
Improver helper function to retrieve ID

### DIFF
--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -1130,7 +1130,7 @@ func (s *AccountService) NewListAccountsParams() *ListAccountsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *AccountService) GetAccountID(name string, opts ...OptionFunc) (string, error) {
+func (s *AccountService) GetAccountID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListAccountsParams{}
 	p.p = make(map[string]interface{})
 
@@ -1138,38 +1138,38 @@ func (s *AccountService) GetAccountID(name string, opts ...OptionFunc) (string, 
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListAccounts(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Accounts[0].Id, nil
+		return l.Accounts[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Accounts {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *AccountService) GetAccountByName(name string, opts ...OptionFunc) (*Account, int, error) {
-	id, err := s.GetAccountID(name, opts...)
+	id, count, err := s.GetAccountID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetAccountByID(id, opts...)
@@ -1728,7 +1728,7 @@ func (s *AccountService) NewListProjectAccountsParams(projectid string) *ListPro
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *AccountService) GetProjectAccountID(keyword string, projectid string, opts ...OptionFunc) (string, error) {
+func (s *AccountService) GetProjectAccountID(keyword string, projectid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListProjectAccountsParams{}
 	p.p = make(map[string]interface{})
 
@@ -1737,31 +1737,31 @@ func (s *AccountService) GetProjectAccountID(keyword string, projectid string, o
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListProjectAccounts(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.ProjectAccounts[0].Id, nil
+		return l.ProjectAccounts[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.ProjectAccounts {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // Lists project's accounts

--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -427,7 +427,7 @@ func (s *AffinityGroupService) NewListAffinityGroupsParams() *ListAffinityGroups
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *AffinityGroupService) GetAffinityGroupID(name string, opts ...OptionFunc) (string, error) {
+func (s *AffinityGroupService) GetAffinityGroupID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListAffinityGroupsParams{}
 	p.p = make(map[string]interface{})
 
@@ -435,38 +435,38 @@ func (s *AffinityGroupService) GetAffinityGroupID(name string, opts ...OptionFun
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListAffinityGroups(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.AffinityGroups[0].Id, nil
+		return l.AffinityGroups[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.AffinityGroups {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *AffinityGroupService) GetAffinityGroupByName(name string, opts ...OptionFunc) (*AffinityGroup, int, error) {
-	id, err := s.GetAffinityGroupID(name, opts...)
+	id, count, err := s.GetAffinityGroupID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetAffinityGroupByID(id, opts...)

--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -1134,7 +1134,7 @@ func (s *AutoScaleService) NewListCountersParams() *ListCountersParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *AutoScaleService) GetCounterID(name string, opts ...OptionFunc) (string, error) {
+func (s *AutoScaleService) GetCounterID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListCountersParams{}
 	p.p = make(map[string]interface{})
 
@@ -1142,38 +1142,38 @@ func (s *AutoScaleService) GetCounterID(name string, opts ...OptionFunc) (string
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListCounters(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Counters[0].Id, nil
+		return l.Counters[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Counters {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *AutoScaleService) GetCounterByName(name string, opts ...OptionFunc) (*Counter, int, error) {
-	id, err := s.GetCounterID(name, opts...)
+	id, count, err := s.GetCounterID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetCounterByID(id, opts...)

--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -636,7 +636,7 @@ func (s *ClusterService) NewListClustersParams() *ListClustersParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ClusterService) GetClusterID(name string, opts ...OptionFunc) (string, error) {
+func (s *ClusterService) GetClusterID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListClustersParams{}
 	p.p = make(map[string]interface{})
 
@@ -644,38 +644,38 @@ func (s *ClusterService) GetClusterID(name string, opts ...OptionFunc) (string, 
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListClusters(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Clusters[0].Id, nil
+		return l.Clusters[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Clusters {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ClusterService) GetClusterByName(name string, opts ...OptionFunc) (*Cluster, int, error) {
-	id, err := s.GetClusterID(name, opts...)
+	id, count, err := s.GetClusterID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetClusterByID(id, opts...)

--- a/cloudstack/DomainService.go
+++ b/cloudstack/DomainService.go
@@ -448,7 +448,7 @@ func (s *DomainService) NewListDomainsParams() *ListDomainsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *DomainService) GetDomainID(name string, opts ...OptionFunc) (string, error) {
+func (s *DomainService) GetDomainID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListDomainsParams{}
 	p.p = make(map[string]interface{})
 
@@ -456,38 +456,38 @@ func (s *DomainService) GetDomainID(name string, opts ...OptionFunc) (string, er
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListDomains(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Domains[0].Id, nil
+		return l.Domains[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Domains {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *DomainService) GetDomainByName(name string, opts ...OptionFunc) (*Domain, int, error) {
-	id, err := s.GetDomainID(name, opts...)
+	id, count, err := s.GetDomainID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetDomainByID(id, opts...)
@@ -699,7 +699,7 @@ func (s *DomainService) NewListDomainChildrenParams() *ListDomainChildrenParams 
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *DomainService) GetDomainChildrenID(name string, opts ...OptionFunc) (string, error) {
+func (s *DomainService) GetDomainChildrenID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListDomainChildrenParams{}
 	p.p = make(map[string]interface{})
 
@@ -707,38 +707,38 @@ func (s *DomainService) GetDomainChildrenID(name string, opts ...OptionFunc) (st
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListDomainChildren(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.DomainChildren[0].Id, nil
+		return l.DomainChildren[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.DomainChildren {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *DomainService) GetDomainChildrenByName(name string, opts ...OptionFunc) (*DomainChildren, int, error) {
-	id, err := s.GetDomainChildrenID(name, opts...)
+	id, count, err := s.GetDomainChildrenID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetDomainChildrenByID(id, opts...)

--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -249,7 +249,7 @@ func (s *GuestOSService) NewListOsCategoriesParams() *ListOsCategoriesParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *GuestOSService) GetOsCategoryID(name string, opts ...OptionFunc) (string, error) {
+func (s *GuestOSService) GetOsCategoryID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListOsCategoriesParams{}
 	p.p = make(map[string]interface{})
 
@@ -257,38 +257,38 @@ func (s *GuestOSService) GetOsCategoryID(name string, opts ...OptionFunc) (strin
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListOsCategories(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.OsCategories[0].Id, nil
+		return l.OsCategories[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.OsCategories {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *GuestOSService) GetOsCategoryByName(name string, opts ...OptionFunc) (*OsCategory, int, error) {
-	id, err := s.GetOsCategoryID(name, opts...)
+	id, count, err := s.GetOsCategoryID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetOsCategoryByID(id, opts...)

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -1037,7 +1037,7 @@ func (s *HostService) NewListHostsParams() *ListHostsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *HostService) GetHostID(name string, opts ...OptionFunc) (string, error) {
+func (s *HostService) GetHostID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListHostsParams{}
 	p.p = make(map[string]interface{})
 
@@ -1045,38 +1045,38 @@ func (s *HostService) GetHostID(name string, opts ...OptionFunc) (string, error)
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListHosts(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Hosts[0].Id, nil
+		return l.Hosts[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Hosts {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *HostService) GetHostByName(name string, opts ...OptionFunc) (*Host, int, error) {
-	id, err := s.GetHostID(name, opts...)
+	id, count, err := s.GetHostID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetHostByID(id, opts...)
@@ -1255,7 +1255,7 @@ func (s *HostService) NewListHostTagsParams() *ListHostTagsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *HostService) GetHostTagID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *HostService) GetHostTagID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListHostTagsParams{}
 	p.p = make(map[string]interface{})
 
@@ -1263,31 +1263,31 @@ func (s *HostService) GetHostTagID(keyword string, opts ...OptionFunc) (string, 
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListHostTags(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.HostTags[0].Id, nil
+		return l.HostTags[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.HostTags {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // Lists host tags

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -754,7 +754,7 @@ func (s *ISOService) NewListIsosParams() *ListIsosParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ISOService) GetIsoID(name string, isofilter string, zoneid string, opts ...OptionFunc) (string, error) {
+func (s *ISOService) GetIsoID(name string, isofilter string, zoneid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListIsosParams{}
 	p.p = make(map[string]interface{})
 
@@ -764,38 +764,38 @@ func (s *ISOService) GetIsoID(name string, isofilter string, zoneid string, opts
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListIsos(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Isos[0].Id, nil
+		return l.Isos[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Isos {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ISOService) GetIsoByName(name string, isofilter string, zoneid string, opts ...OptionFunc) (*Iso, int, error) {
-	id, err := s.GetIsoID(name, isofilter, zoneid, opts...)
+	id, count, err := s.GetIsoID(name, isofilter, zoneid, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetIsoByID(id, opts...)

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -419,7 +419,7 @@ func (s *ImageStoreService) NewListImageStoresParams() *ListImageStoresParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ImageStoreService) GetImageStoreID(name string, opts ...OptionFunc) (string, error) {
+func (s *ImageStoreService) GetImageStoreID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListImageStoresParams{}
 	p.p = make(map[string]interface{})
 
@@ -427,38 +427,38 @@ func (s *ImageStoreService) GetImageStoreID(name string, opts ...OptionFunc) (st
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListImageStores(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.ImageStores[0].Id, nil
+		return l.ImageStores[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.ImageStores {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ImageStoreService) GetImageStoreByName(name string, opts ...OptionFunc) (*ImageStore, int, error) {
-	id, err := s.GetImageStoreID(name, opts...)
+	id, count, err := s.GetImageStoreID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetImageStoreByID(id, opts...)
@@ -801,7 +801,7 @@ func (s *ImageStoreService) NewListSecondaryStagingStoresParams() *ListSecondary
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ImageStoreService) GetSecondaryStagingStoreID(name string, opts ...OptionFunc) (string, error) {
+func (s *ImageStoreService) GetSecondaryStagingStoreID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListSecondaryStagingStoresParams{}
 	p.p = make(map[string]interface{})
 
@@ -809,38 +809,38 @@ func (s *ImageStoreService) GetSecondaryStagingStoreID(name string, opts ...Opti
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListSecondaryStagingStores(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.SecondaryStagingStores[0].Id, nil
+		return l.SecondaryStagingStores[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.SecondaryStagingStores {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ImageStoreService) GetSecondaryStagingStoreByName(name string, opts ...OptionFunc) (*SecondaryStagingStore, int, error) {
-	id, err := s.GetSecondaryStagingStoreID(name, opts...)
+	id, count, err := s.GetSecondaryStagingStoreID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetSecondaryStagingStoreByID(id, opts...)

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -1067,7 +1067,7 @@ func (s *LoadBalancerService) NewListLoadBalancerRulesParams() *ListLoadBalancer
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *LoadBalancerService) GetLoadBalancerRuleID(name string, opts ...OptionFunc) (string, error) {
+func (s *LoadBalancerService) GetLoadBalancerRuleID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListLoadBalancerRulesParams{}
 	p.p = make(map[string]interface{})
 
@@ -1075,38 +1075,38 @@ func (s *LoadBalancerService) GetLoadBalancerRuleID(name string, opts ...OptionF
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListLoadBalancerRules(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.LoadBalancerRules[0].Id, nil
+		return l.LoadBalancerRules[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.LoadBalancerRules {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *LoadBalancerService) GetLoadBalancerRuleByName(name string, opts ...OptionFunc) (*LoadBalancerRule, int, error) {
-	id, err := s.GetLoadBalancerRuleID(name, opts...)
+	id, count, err := s.GetLoadBalancerRuleID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetLoadBalancerRuleByID(id, opts...)
@@ -3661,7 +3661,7 @@ func (s *LoadBalancerService) NewListGlobalLoadBalancerRulesParams() *ListGlobal
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *LoadBalancerService) GetGlobalLoadBalancerRuleID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *LoadBalancerService) GetGlobalLoadBalancerRuleID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListGlobalLoadBalancerRulesParams{}
 	p.p = make(map[string]interface{})
 
@@ -3669,38 +3669,38 @@ func (s *LoadBalancerService) GetGlobalLoadBalancerRuleID(keyword string, opts .
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListGlobalLoadBalancerRules(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.GlobalLoadBalancerRules[0].Id, nil
+		return l.GlobalLoadBalancerRules[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.GlobalLoadBalancerRules {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *LoadBalancerService) GetGlobalLoadBalancerRuleByName(name string, opts ...OptionFunc) (*GlobalLoadBalancerRule, int, error) {
-	id, err := s.GetGlobalLoadBalancerRuleID(name, opts...)
+	id, count, err := s.GetGlobalLoadBalancerRuleID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetGlobalLoadBalancerRuleByID(id, opts...)
@@ -4408,7 +4408,7 @@ func (s *LoadBalancerService) NewListLoadBalancersParams() *ListLoadBalancersPar
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *LoadBalancerService) GetLoadBalancerID(name string, opts ...OptionFunc) (string, error) {
+func (s *LoadBalancerService) GetLoadBalancerID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListLoadBalancersParams{}
 	p.p = make(map[string]interface{})
 
@@ -4416,38 +4416,38 @@ func (s *LoadBalancerService) GetLoadBalancerID(name string, opts ...OptionFunc)
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListLoadBalancers(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.LoadBalancers[0].Id, nil
+		return l.LoadBalancers[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.LoadBalancers {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *LoadBalancerService) GetLoadBalancerByName(name string, opts ...OptionFunc) (*LoadBalancer, int, error) {
-	id, err := s.GetLoadBalancerID(name, opts...)
+	id, count, err := s.GetLoadBalancerID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetLoadBalancerByID(id, opts...)

--- a/cloudstack/NetworkACLService.go
+++ b/cloudstack/NetworkACLService.go
@@ -1258,7 +1258,7 @@ func (s *NetworkACLService) NewListNetworkACLListsParams() *ListNetworkACLListsP
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkACLService) GetNetworkACLListID(name string, opts ...OptionFunc) (string, error) {
+func (s *NetworkACLService) GetNetworkACLListID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListNetworkACLListsParams{}
 	p.p = make(map[string]interface{})
 
@@ -1266,38 +1266,38 @@ func (s *NetworkACLService) GetNetworkACLListID(name string, opts ...OptionFunc)
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListNetworkACLLists(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.NetworkACLLists[0].Id, nil
+		return l.NetworkACLLists[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.NetworkACLLists {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *NetworkACLService) GetNetworkACLListByName(name string, opts ...OptionFunc) (*NetworkACLList, int, error) {
-	id, err := s.GetNetworkACLListID(name, opts...)
+	id, count, err := s.GetNetworkACLListID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetNetworkACLListByID(id, opts...)

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -808,7 +808,7 @@ func (s *NetworkOfferingService) NewListNetworkOfferingsParams() *ListNetworkOff
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkOfferingService) GetNetworkOfferingID(name string, opts ...OptionFunc) (string, error) {
+func (s *NetworkOfferingService) GetNetworkOfferingID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListNetworkOfferingsParams{}
 	p.p = make(map[string]interface{})
 
@@ -816,38 +816,38 @@ func (s *NetworkOfferingService) GetNetworkOfferingID(name string, opts ...Optio
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListNetworkOfferings(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.NetworkOfferings[0].Id, nil
+		return l.NetworkOfferings[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.NetworkOfferings {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *NetworkOfferingService) GetNetworkOfferingByName(name string, opts ...OptionFunc) (*NetworkOffering, int, error) {
-	id, err := s.GetNetworkOfferingID(name, opts...)
+	id, count, err := s.GetNetworkOfferingID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetNetworkOfferingByID(id, opts...)

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -935,7 +935,7 @@ func (s *NetworkService) NewListNetworksParams() *ListNetworksParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkService) GetNetworkID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *NetworkService) GetNetworkID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListNetworksParams{}
 	p.p = make(map[string]interface{})
 
@@ -943,38 +943,38 @@ func (s *NetworkService) GetNetworkID(keyword string, opts ...OptionFunc) (strin
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListNetworks(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.Networks[0].Id, nil
+		return l.Networks[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Networks {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *NetworkService) GetNetworkByName(name string, opts ...OptionFunc) (*Network, int, error) {
-	id, err := s.GetNetworkID(name, opts...)
+	id, count, err := s.GetNetworkID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetNetworkByID(id, opts...)
@@ -1788,7 +1788,7 @@ func (s *NetworkService) NewListPhysicalNetworksParams() *ListPhysicalNetworksPa
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkService) GetPhysicalNetworkID(name string, opts ...OptionFunc) (string, error) {
+func (s *NetworkService) GetPhysicalNetworkID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListPhysicalNetworksParams{}
 	p.p = make(map[string]interface{})
 
@@ -1796,38 +1796,38 @@ func (s *NetworkService) GetPhysicalNetworkID(name string, opts ...OptionFunc) (
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListPhysicalNetworks(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.PhysicalNetworks[0].Id, nil
+		return l.PhysicalNetworks[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.PhysicalNetworks {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *NetworkService) GetPhysicalNetworkByName(name string, opts ...OptionFunc) (*PhysicalNetwork, int, error) {
-	id, err := s.GetPhysicalNetworkID(name, opts...)
+	id, count, err := s.GetPhysicalNetworkID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetPhysicalNetworkByID(id, opts...)
@@ -2409,7 +2409,7 @@ func (s *NetworkService) NewListNetworkServiceProvidersParams() *ListNetworkServ
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkService) GetNetworkServiceProviderID(name string, opts ...OptionFunc) (string, error) {
+func (s *NetworkService) GetNetworkServiceProviderID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListNetworkServiceProvidersParams{}
 	p.p = make(map[string]interface{})
 
@@ -2417,31 +2417,31 @@ func (s *NetworkService) GetNetworkServiceProviderID(name string, opts ...Option
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListNetworkServiceProviders(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.NetworkServiceProviders[0].Id, nil
+		return l.NetworkServiceProviders[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.NetworkServiceProviders {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // Lists network serviceproviders for a given physical network.
@@ -3122,7 +3122,7 @@ func (s *NetworkService) NewListPaloAltoFirewallNetworksParams(lbdeviceid string
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkService) GetPaloAltoFirewallNetworkID(keyword string, lbdeviceid string, opts ...OptionFunc) (string, error) {
+func (s *NetworkService) GetPaloAltoFirewallNetworkID(keyword string, lbdeviceid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListPaloAltoFirewallNetworksParams{}
 	p.p = make(map[string]interface{})
 
@@ -3131,31 +3131,31 @@ func (s *NetworkService) GetPaloAltoFirewallNetworkID(keyword string, lbdeviceid
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListPaloAltoFirewallNetworks(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.PaloAltoFirewallNetworks[0].Id, nil
+		return l.PaloAltoFirewallNetworks[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.PaloAltoFirewallNetworks {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // lists network that are using Palo Alto firewall device
@@ -3323,7 +3323,7 @@ func (s *NetworkService) NewListNetscalerLoadBalancerNetworksParams(lbdeviceid s
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkService) GetNetscalerLoadBalancerNetworkID(keyword string, lbdeviceid string, opts ...OptionFunc) (string, error) {
+func (s *NetworkService) GetNetscalerLoadBalancerNetworkID(keyword string, lbdeviceid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListNetscalerLoadBalancerNetworksParams{}
 	p.p = make(map[string]interface{})
 
@@ -3332,31 +3332,31 @@ func (s *NetworkService) GetNetscalerLoadBalancerNetworkID(keyword string, lbdev
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListNetscalerLoadBalancerNetworks(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.NetscalerLoadBalancerNetworks[0].Id, nil
+		return l.NetscalerLoadBalancerNetworks[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.NetscalerLoadBalancerNetworks {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // lists network that are using a netscaler load balancer device
@@ -3524,7 +3524,7 @@ func (s *NetworkService) NewListNiciraNvpDeviceNetworksParams(nvpdeviceid string
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *NetworkService) GetNiciraNvpDeviceNetworkID(keyword string, nvpdeviceid string, opts ...OptionFunc) (string, error) {
+func (s *NetworkService) GetNiciraNvpDeviceNetworkID(keyword string, nvpdeviceid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListNiciraNvpDeviceNetworksParams{}
 	p.p = make(map[string]interface{})
 
@@ -3533,31 +3533,31 @@ func (s *NetworkService) GetNiciraNvpDeviceNetworkID(keyword string, nvpdeviceid
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListNiciraNvpDeviceNetworks(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.NiciraNvpDeviceNetworks[0].Id, nil
+		return l.NiciraNvpDeviceNetworks[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.NiciraNvpDeviceNetworks {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // lists network that are using a nicira nvp device

--- a/cloudstack/PodService.go
+++ b/cloudstack/PodService.go
@@ -463,7 +463,7 @@ func (s *PodService) NewListPodsParams() *ListPodsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *PodService) GetPodID(name string, opts ...OptionFunc) (string, error) {
+func (s *PodService) GetPodID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListPodsParams{}
 	p.p = make(map[string]interface{})
 
@@ -471,38 +471,38 @@ func (s *PodService) GetPodID(name string, opts ...OptionFunc) (string, error) {
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListPods(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Pods[0].Id, nil
+		return l.Pods[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Pods {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *PodService) GetPodByName(name string, opts ...OptionFunc) (*Pod, int, error) {
-	id, err := s.GetPodID(name, opts...)
+	id, count, err := s.GetPodID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetPodByID(id, opts...)

--- a/cloudstack/ProjectService.go
+++ b/cloudstack/ProjectService.go
@@ -805,7 +805,7 @@ func (s *ProjectService) NewListProjectsParams() *ListProjectsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ProjectService) GetProjectID(name string, opts ...OptionFunc) (string, error) {
+func (s *ProjectService) GetProjectID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListProjectsParams{}
 	p.p = make(map[string]interface{})
 
@@ -813,38 +813,38 @@ func (s *ProjectService) GetProjectID(name string, opts ...OptionFunc) (string, 
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListProjects(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Projects[0].Id, nil
+		return l.Projects[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Projects {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ProjectService) GetProjectByName(name string, opts ...OptionFunc) (*Project, int, error) {
-	id, err := s.GetProjectID(name, opts...)
+	id, count, err := s.GetProjectID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetProjectByID(id, opts...)

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -80,7 +80,7 @@ func (s *ResourcetagsService) NewListStorageTagsParams() *ListStorageTagsParams 
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ResourcetagsService) GetStorageTagID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *ResourcetagsService) GetStorageTagID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListStorageTagsParams{}
 	p.p = make(map[string]interface{})
 
@@ -88,31 +88,31 @@ func (s *ResourcetagsService) GetStorageTagID(keyword string, opts ...OptionFunc
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListStorageTags(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.StorageTags[0].Id, nil
+		return l.StorageTags[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.StorageTags {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // Lists storage tags

--- a/cloudstack/RouterService.go
+++ b/cloudstack/RouterService.go
@@ -952,7 +952,7 @@ func (s *RouterService) NewListRoutersParams() *ListRoutersParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *RouterService) GetRouterID(name string, opts ...OptionFunc) (string, error) {
+func (s *RouterService) GetRouterID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListRoutersParams{}
 	p.p = make(map[string]interface{})
 
@@ -960,38 +960,38 @@ func (s *RouterService) GetRouterID(name string, opts ...OptionFunc) (string, er
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListRouters(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Routers[0].Id, nil
+		return l.Routers[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Routers {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *RouterService) GetRouterByName(name string, opts ...OptionFunc) (*Router, int, error) {
-	id, err := s.GetRouterID(name, opts...)
+	id, count, err := s.GetRouterID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetRouterByID(id, opts...)

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -717,7 +717,7 @@ func (s *ServiceOfferingService) NewListServiceOfferingsParams() *ListServiceOff
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ServiceOfferingService) GetServiceOfferingID(name string, opts ...OptionFunc) (string, error) {
+func (s *ServiceOfferingService) GetServiceOfferingID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListServiceOfferingsParams{}
 	p.p = make(map[string]interface{})
 
@@ -725,38 +725,38 @@ func (s *ServiceOfferingService) GetServiceOfferingID(name string, opts ...Optio
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListServiceOfferings(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.ServiceOfferings[0].Id, nil
+		return l.ServiceOfferings[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.ServiceOfferings {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ServiceOfferingService) GetServiceOfferingByName(name string, opts ...OptionFunc) (*ServiceOffering, int, error) {
-	id, err := s.GetServiceOfferingID(name, opts...)
+	id, count, err := s.GetServiceOfferingID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetServiceOfferingByID(id, opts...)

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -374,7 +374,7 @@ func (s *SnapshotService) NewListSnapshotsParams() *ListSnapshotsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *SnapshotService) GetSnapshotID(name string, opts ...OptionFunc) (string, error) {
+func (s *SnapshotService) GetSnapshotID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListSnapshotsParams{}
 	p.p = make(map[string]interface{})
 
@@ -382,38 +382,38 @@ func (s *SnapshotService) GetSnapshotID(name string, opts ...OptionFunc) (string
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListSnapshots(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Snapshots[0].Id, nil
+		return l.Snapshots[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Snapshots {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *SnapshotService) GetSnapshotByName(name string, opts ...OptionFunc) (*Snapshot, int, error) {
-	id, err := s.GetSnapshotID(name, opts...)
+	id, count, err := s.GetSnapshotID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetSnapshotByID(id, opts...)
@@ -1275,7 +1275,7 @@ func (s *SnapshotService) NewListVMSnapshotParams() *ListVMSnapshotParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *SnapshotService) GetVMSnapshotID(name string, opts ...OptionFunc) (string, error) {
+func (s *SnapshotService) GetVMSnapshotID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListVMSnapshotParams{}
 	p.p = make(map[string]interface{})
 
@@ -1283,31 +1283,31 @@ func (s *SnapshotService) GetVMSnapshotID(name string, opts ...OptionFunc) (stri
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListVMSnapshot(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.VMSnapshot[0].Id, nil
+		return l.VMSnapshot[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.VMSnapshot {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // List virtual machine snapshot by conditions

--- a/cloudstack/SwiftService.go
+++ b/cloudstack/SwiftService.go
@@ -182,7 +182,7 @@ func (s *SwiftService) NewListSwiftsParams() *ListSwiftsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *SwiftService) GetSwiftID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *SwiftService) GetSwiftID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListSwiftsParams{}
 	p.p = make(map[string]interface{})
 
@@ -190,31 +190,31 @@ func (s *SwiftService) GetSwiftID(keyword string, opts ...OptionFunc) (string, e
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListSwifts(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.Swifts[0].Id, nil
+		return l.Swifts[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Swifts {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // List Swift.

--- a/cloudstack/SystemVMService.go
+++ b/cloudstack/SystemVMService.go
@@ -572,7 +572,7 @@ func (s *SystemVMService) NewListSystemVmsParams() *ListSystemVmsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *SystemVMService) GetSystemVmID(name string, opts ...OptionFunc) (string, error) {
+func (s *SystemVMService) GetSystemVmID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListSystemVmsParams{}
 	p.p = make(map[string]interface{})
 
@@ -580,38 +580,38 @@ func (s *SystemVMService) GetSystemVmID(name string, opts ...OptionFunc) (string
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListSystemVms(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.SystemVms[0].Id, nil
+		return l.SystemVms[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.SystemVms {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *SystemVMService) GetSystemVmByName(name string, opts ...OptionFunc) (*SystemVm, int, error) {
-	id, err := s.GetSystemVmID(name, opts...)
+	id, count, err := s.GetSystemVmID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetSystemVmByID(id, opts...)

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -1314,7 +1314,7 @@ func (s *TemplateService) NewListTemplatesParams(templatefilter string) *ListTem
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *TemplateService) GetTemplateID(name string, templatefilter string, zoneid string, opts ...OptionFunc) (string, error) {
+func (s *TemplateService) GetTemplateID(name string, templatefilter string, zoneid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListTemplatesParams{}
 	p.p = make(map[string]interface{})
 
@@ -1324,38 +1324,38 @@ func (s *TemplateService) GetTemplateID(name string, templatefilter string, zone
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListTemplates(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Templates[0].Id, nil
+		return l.Templates[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Templates {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *TemplateService) GetTemplateByName(name string, templatefilter string, zoneid string, opts ...OptionFunc) (*Template, int, error) {
-	id, err := s.GetTemplateID(name, templatefilter, zoneid, opts...)
+	id, count, err := s.GetTemplateID(name, templatefilter, zoneid, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetTemplateByID(id, templatefilter, opts...)

--- a/cloudstack/UCSService.go
+++ b/cloudstack/UCSService.go
@@ -202,7 +202,7 @@ func (s *UCSService) NewListUcsManagersParams() *ListUcsManagersParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *UCSService) GetUcsManagerID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *UCSService) GetUcsManagerID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListUcsManagersParams{}
 	p.p = make(map[string]interface{})
 
@@ -210,38 +210,38 @@ func (s *UCSService) GetUcsManagerID(keyword string, opts ...OptionFunc) (string
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListUcsManagers(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.UcsManagers[0].Id, nil
+		return l.UcsManagers[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.UcsManagers {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *UCSService) GetUcsManagerByName(name string, opts ...OptionFunc) (*UcsManager, int, error) {
-	id, err := s.GetUcsManagerID(name, opts...)
+	id, count, err := s.GetUcsManagerID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetUcsManagerByID(id, opts...)

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -325,7 +325,7 @@ func (s *UsageService) NewListTrafficTypesParams(physicalnetworkid string) *List
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *UsageService) GetTrafficTypeID(keyword string, physicalnetworkid string, opts ...OptionFunc) (string, error) {
+func (s *UsageService) GetTrafficTypeID(keyword string, physicalnetworkid string, opts ...OptionFunc) (string, int, error) {
 	p := &ListTrafficTypesParams{}
 	p.p = make(map[string]interface{})
 
@@ -334,31 +334,31 @@ func (s *UsageService) GetTrafficTypeID(keyword string, physicalnetworkid string
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListTrafficTypes(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.TrafficTypes[0].Id, nil
+		return l.TrafficTypes[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.TrafficTypes {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // Lists traffic types of a given physical network.

--- a/cloudstack/VMGroupService.go
+++ b/cloudstack/VMGroupService.go
@@ -368,7 +368,7 @@ func (s *VMGroupService) NewListInstanceGroupsParams() *ListInstanceGroupsParams
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *VMGroupService) GetInstanceGroupID(name string, opts ...OptionFunc) (string, error) {
+func (s *VMGroupService) GetInstanceGroupID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListInstanceGroupsParams{}
 	p.p = make(map[string]interface{})
 
@@ -376,38 +376,38 @@ func (s *VMGroupService) GetInstanceGroupID(name string, opts ...OptionFunc) (st
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListInstanceGroups(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.InstanceGroups[0].Id, nil
+		return l.InstanceGroups[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.InstanceGroups {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *VMGroupService) GetInstanceGroupByName(name string, opts ...OptionFunc) (*InstanceGroup, int, error) {
-	id, err := s.GetInstanceGroupID(name, opts...)
+	id, count, err := s.GetInstanceGroupID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetInstanceGroupByID(id, opts...)

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -578,7 +578,7 @@ func (s *VPCService) NewListVPCsParams() *ListVPCsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *VPCService) GetVPCID(name string, opts ...OptionFunc) (string, error) {
+func (s *VPCService) GetVPCID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListVPCsParams{}
 	p.p = make(map[string]interface{})
 
@@ -586,38 +586,38 @@ func (s *VPCService) GetVPCID(name string, opts ...OptionFunc) (string, error) {
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListVPCs(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.VPCs[0].Id, nil
+		return l.VPCs[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.VPCs {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *VPCService) GetVPCByName(name string, opts ...OptionFunc) (*VPC, int, error) {
-	id, err := s.GetVPCID(name, opts...)
+	id, count, err := s.GetVPCID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetVPCByID(id, opts...)
@@ -1818,7 +1818,7 @@ func (s *VPCService) NewListVPCOfferingsParams() *ListVPCOfferingsParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *VPCService) GetVPCOfferingID(name string, opts ...OptionFunc) (string, error) {
+func (s *VPCService) GetVPCOfferingID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListVPCOfferingsParams{}
 	p.p = make(map[string]interface{})
 
@@ -1826,38 +1826,38 @@ func (s *VPCService) GetVPCOfferingID(name string, opts ...OptionFunc) (string, 
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListVPCOfferings(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.VPCOfferings[0].Id, nil
+		return l.VPCOfferings[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.VPCOfferings {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *VPCService) GetVPCOfferingByName(name string, opts ...OptionFunc) (*VPCOffering, int, error) {
-	id, err := s.GetVPCOfferingID(name, opts...)
+	id, count, err := s.GetVPCOfferingID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetVPCOfferingByID(id, opts...)

--- a/cloudstack/VPNService.go
+++ b/cloudstack/VPNService.go
@@ -2097,7 +2097,7 @@ func (s *VPNService) NewListVpnCustomerGatewaysParams() *ListVpnCustomerGateways
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *VPNService) GetVpnCustomerGatewayID(keyword string, opts ...OptionFunc) (string, error) {
+func (s *VPNService) GetVpnCustomerGatewayID(keyword string, opts ...OptionFunc) (string, int, error) {
 	p := &ListVpnCustomerGatewaysParams{}
 	p.p = make(map[string]interface{})
 
@@ -2105,38 +2105,38 @@ func (s *VPNService) GetVpnCustomerGatewayID(keyword string, opts ...OptionFunc)
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListVpnCustomerGateways(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", keyword, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", keyword, l)
 	}
 
 	if l.Count == 1 {
-		return l.VpnCustomerGateways[0].Id, nil
+		return l.VpnCustomerGateways[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.VpnCustomerGateways {
 			if v.Name == keyword {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", keyword, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *VPNService) GetVpnCustomerGatewayByName(name string, opts ...OptionFunc) (*VpnCustomerGateway, int, error) {
-	id, err := s.GetVpnCustomerGatewayID(name, opts...)
+	id, count, err := s.GetVpnCustomerGatewayID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetVpnCustomerGatewayByID(id, opts...)

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -2592,7 +2592,7 @@ func (s *VirtualMachineService) NewListVirtualMachinesParams() *ListVirtualMachi
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *VirtualMachineService) GetVirtualMachineID(name string, opts ...OptionFunc) (string, error) {
+func (s *VirtualMachineService) GetVirtualMachineID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListVirtualMachinesParams{}
 	p.p = make(map[string]interface{})
 
@@ -2600,38 +2600,38 @@ func (s *VirtualMachineService) GetVirtualMachineID(name string, opts ...OptionF
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListVirtualMachines(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.VirtualMachines[0].Id, nil
+		return l.VirtualMachines[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.VirtualMachines {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *VirtualMachineService) GetVirtualMachineByName(name string, opts ...OptionFunc) (*VirtualMachine, int, error) {
-	id, err := s.GetVirtualMachineID(name, opts...)
+	id, count, err := s.GetVirtualMachineID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetVirtualMachineByID(id, opts...)

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -1126,7 +1126,7 @@ func (s *VolumeService) NewListVolumesParams() *ListVolumesParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *VolumeService) GetVolumeID(name string, opts ...OptionFunc) (string, error) {
+func (s *VolumeService) GetVolumeID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListVolumesParams{}
 	p.p = make(map[string]interface{})
 
@@ -1134,38 +1134,38 @@ func (s *VolumeService) GetVolumeID(name string, opts ...OptionFunc) (string, er
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListVolumes(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Volumes[0].Id, nil
+		return l.Volumes[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Volumes {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *VolumeService) GetVolumeByName(name string, opts ...OptionFunc) (*Volume, int, error) {
-	id, err := s.GetVolumeID(name, opts...)
+	id, count, err := s.GetVolumeID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetVolumeByID(id, opts...)

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -724,7 +724,7 @@ func (s *ZoneService) NewListZonesParams() *ListZonesParams {
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *ZoneService) GetZoneID(name string, opts ...OptionFunc) (string, error) {
+func (s *ZoneService) GetZoneID(name string, opts ...OptionFunc) (string, int, error) {
 	p := &ListZonesParams{}
 	p.p = make(map[string]interface{})
 
@@ -732,38 +732,38 @@ func (s *ZoneService) GetZoneID(name string, opts ...OptionFunc) (string, error)
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {
-			return "", err
+			return "", -1, err
 		}
 	}
 
 	l, err := s.ListZones(p)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	if l.Count == 0 {
-		return "", fmt.Errorf("No match found for %s: %+v", name, l)
+		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
 
 	if l.Count == 1 {
-		return l.Zones[0].Id, nil
+		return l.Zones[0].Id, l.Count, nil
 	}
 
 	if l.Count > 1 {
 		for _, v := range l.Zones {
 			if v.Name == name {
-				return v.Id, nil
+				return v.Id, l.Count, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
+	return "", l.Count, fmt.Errorf("Could not find an exact match for %s: %+v", name, l)
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
 func (s *ZoneService) GetZoneByName(name string, opts ...OptionFunc) (*Zone, int, error) {
-	id, err := s.GetZoneID(name, opts...)
+	id, count, err := s.GetZoneID(name, opts...)
 	if err != nil {
-		return nil, -1, err
+		return nil, count, err
 	}
 
 	r, count, err := s.GetZoneByID(id, opts...)

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -398,7 +398,7 @@ func WithProject(project string) OptionFunc {
 		}
 
 		if !IsID(project) {
-			id, err := cs.Project.GetProjectID(project)
+			id, _, err := cs.Project.GetProjectID(project)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This changes the signature of the custom helper function `Get...ID` from:

```go
Get...ID(name string, opts ...OptionFunc) (string, error)
```
To:
```go
Get...ID(name string, opts ...OptionFunc) (string, int, error)
```
Where the `int` shows the number of results, or -1 if there was an error. This way you can distinguish real errors, with a `not-found` (0 results) error.