### PR TITLE
Fix the ListLoadBalancerRuleInstances response

### DIFF
--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -1771,7 +1771,6 @@ func (s *ISOService) GetIsoPermissionByID(id string, opts ...OptionFunc) (*IsoPe
 	p.p = make(map[string]interface{})
 
 	p.p["id"] = id
-	p.p["id"] = id
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -1959,11 +1959,10 @@ func (s *LoadBalancerService) NewListLoadBalancerRuleInstancesParams(id string) 
 }
 
 // This is a courtesy helper function, which in some cases may not work as expected!
-func (s *LoadBalancerService) GetLoadBalancerRuleInstanceByID(id string, opts ...OptionFunc) (*LoadBalancerRuleInstance, int, error) {
+func (s *LoadBalancerService) GetLoadBalancerRuleInstanceByID(id string, opts ...OptionFunc) (*VirtualMachine, int, error) {
 	p := &ListLoadBalancerRuleInstancesParams{}
 	p.p = make(map[string]interface{})
 
-	p.p["id"] = id
 	p.p["id"] = id
 
 	for _, fn := range opts {
@@ -2008,7 +2007,8 @@ func (s *LoadBalancerService) ListLoadBalancerRuleInstances(p *ListLoadBalancerR
 
 type ListLoadBalancerRuleInstancesResponse struct {
 	Count                     int                         `json:"count"`
-	LoadBalancerRuleInstances []*LoadBalancerRuleInstance `json:"lbrulevmidip"`
+	LBRuleVMIDIPs             []*LoadBalancerRuleInstance `json:"lbrulevmidip,omitempty"`
+	LoadBalancerRuleInstances []*VirtualMachine           `json:"loadbalancerruleinstance,omitempty"`
 }
 
 type LoadBalancerRuleInstance struct {

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -1628,7 +1628,6 @@ func (s *TemplateService) GetTemplatePermissionByID(id string, opts ...OptionFun
 	p.p = make(map[string]interface{})
 
 	p.p["id"] = id
-	p.p["id"] = id
 
 	for _, fn := range opts {
 		if err := fn(s.cs, p); err != nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -904,7 +904,11 @@ func (s *service) generateHelperFuncs(a *API) {
 					p("%s %s, ", s.parseParamName(ap.Name), mapType(ap.Type))
 				}
 			}
-			pn("opts ...OptionFunc) (*%s, int, error) {", parseSingular(ln))
+			if ln == "LoadBalancerRuleInstances" {
+				pn("opts ...OptionFunc) (*VirtualMachine, int, error) {")
+			} else {
+				pn("opts ...OptionFunc) (*%s, int, error) {", parseSingular(ln))
+			}
 
 			// Generate the function body
 			pn("	p := &List%sParams{}", ln)
@@ -912,7 +916,7 @@ func (s *service) generateHelperFuncs(a *API) {
 			pn("")
 			pn("	p.p[\"id\"] = id")
 			for _, ap := range a.Params {
-				if ap.Required {
+				if ap.Required && s.parseParamName(ap.Name) != "id" {
 					pn("	p.p[\"%s\"] = %s", s.parseParamName(ap.Name), s.parseParamName(ap.Name))
 				}
 			}
@@ -1102,7 +1106,8 @@ func (s *service) generateResponseType(a *API) {
 		case "listEgressFirewallRules":
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "firewallrule")
 		case "listLoadBalancerRuleInstances":
-			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "lbrulevmidip")
+			pn("	LBRuleVMIDIPs []*%s `json:\"%s,omitempty\"`", parseSingular(ln), "lbrulevmidip")
+			pn("	LoadBalancerRuleInstances []*VirtualMachine `json:\"%s,omitempty\"`", strings.ToLower(parseSingular(ln)))
 		case "registerTemplate":
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "template")
 		default:


### PR DESCRIPTION
This one can have two possible response types, depending on the query values used. By adding this, both types are supported.