### PR TITLE
Fix a bug that created bad parameter names

### DIFF
--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -98,7 +98,7 @@ func (p *CreateAffinityGroupParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["affinityGroupType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -108,7 +108,7 @@ func (s *AffinityGroupService) NewCreateAffinityGroupParams(name string, affinit
 	p := &CreateAffinityGroupParams{}
 	p.p = make(map[string]interface{})
 	p.p["name"] = name
-	p.p["affinityGroupType"] = affinityGroupType
+	p.p["type"] = affinityGroupType
 	return p
 }
 
@@ -406,7 +406,7 @@ func (p *ListAffinityGroupsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["affinityGroupType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/AlertService.go
+++ b/cloudstack/AlertService.go
@@ -100,7 +100,7 @@ func (p *ListAlertsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["alertType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -275,7 +275,7 @@ func (p *ArchiveAlertsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["alertType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -359,7 +359,7 @@ func (p *DeleteAlertsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["alertType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -446,7 +446,7 @@ func (p *GenerateAlertParams) SetType(v int) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["alertType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -465,7 +465,7 @@ func (s *AlertService) NewGenerateAlertParams(description string, name string, a
 	p.p = make(map[string]interface{})
 	p.p["description"] = description
 	p.p["name"] = name
-	p.p["alertType"] = alertType
+	p.p["type"] = alertType
 	return p
 }
 

--- a/cloudstack/DomainService.go
+++ b/cloudstack/DomainService.go
@@ -912,7 +912,7 @@ func (p *LinkDomainToLdapParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["domainType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -924,7 +924,7 @@ func (s *DomainService) NewLinkDomainToLdapParams(accounttype int, domainid stri
 	p.p["accounttype"] = accounttype
 	p.p["domainid"] = domainid
 	p.p["name"] = name
-	p.p["domainType"] = domainType
+	p.p["type"] = domainType
 	return p
 }
 

--- a/cloudstack/EventService.go
+++ b/cloudstack/EventService.go
@@ -203,7 +203,7 @@ func (p *ListEventsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["eventType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -379,7 +379,7 @@ func (p *ArchiveEventsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["eventType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -463,7 +463,7 @@ func (p *DeleteEventsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["eventType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -930,7 +930,7 @@ func (p *CreateFirewallRuleParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["firewallType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -1590,7 +1590,7 @@ func (p *CreateEgressFirewallRuleParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["firewallType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -1008,7 +1008,7 @@ func (p *ListHostsParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["hostType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -906,7 +906,7 @@ func (p *ListNetworksParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["networkType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/StoragePoolService.go
+++ b/cloudstack/StoragePoolService.go
@@ -76,7 +76,7 @@ func (p *ListStorageProvidersParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["storagePoolType"] = v
+	p.p["type"] = v
 	return
 }
 
@@ -85,7 +85,7 @@ func (p *ListStorageProvidersParams) SetType(v string) {
 func (s *StoragePoolService) NewListStorageProvidersParams(storagePoolType string) *ListStorageProvidersParams {
 	p := &ListStorageProvidersParams{}
 	p.p = make(map[string]interface{})
-	p.p["storagePoolType"] = storagePoolType
+	p.p["type"] = storagePoolType
 	return p
 }
 

--- a/cloudstack/SystemCapacityService.go
+++ b/cloudstack/SystemCapacityService.go
@@ -125,7 +125,7 @@ func (p *ListCapacityParams) SetType(v int) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["systemCapacityType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -811,7 +811,7 @@ func (p *ListUsageRecordsParams) SetType(v int64) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["usageType"] = v
+	p.p["type"] = v
 	return
 }
 

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -1097,7 +1097,7 @@ func (p *ListVolumesParams) SetType(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
 	}
-	p.p["volumeType"] = v
+	p.p["type"] = v
 	return
 }
 


### PR DESCRIPTION
When the parameter is called `type` we have to convert this to prevent using the reserved keyword `type` as a variable name. But we were doing it in a few other locations as well. That’s fixed now.