### PR TITLE
Fix a bug in the listAffinityGroup call

### DIFF
--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -444,6 +444,10 @@ func (s *AffinityGroupService) GetAffinityGroupID(name string, opts ...OptionFun
 		return "", -1, err
 	}
 
+	// This is needed because of a bug with the listAffinityGroup call. It reports the
+	// number of VirtualMachines in the groups as being the number of groups found.
+	l.Count = len(l.AffinityGroups)
+
 	if l.Count == 0 {
 		return "", l.Count, fmt.Errorf("No match found for %s: %+v", name, l)
 	}
@@ -498,6 +502,10 @@ func (s *AffinityGroupService) GetAffinityGroupByID(id string, opts ...OptionFun
 		}
 		return nil, -1, err
 	}
+
+	// This is needed because of a bug with the listAffinityGroup call. It reports the
+	// number of VirtualMachines in the groups as being the number of groups found.
+	l.Count = len(l.AffinityGroups)
 
 	if l.Count == 0 {
 		return nil, l.Count, fmt.Errorf("No match found for %s: %+v", id, l)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -815,6 +815,12 @@ func (s *service) generateHelperFuncs(a *API) {
 			pn("		return \"\", -1, err")
 			pn("	}")
 			pn("")
+			if ln == "AffinityGroups" {
+				pn("	// This is needed because of a bug with the listAffinityGroup call. It reports the")
+				pn("	// number of VirtualMachines in the groups as being the number of groups found.")
+				pn("	l.Count = len(l.%s)", ln)
+				pn("")
+			}
 			pn("	if l.Count == 0 {")
 			pn("	  return \"\", l.Count, fmt.Errorf(\"No match found for %%s: %%+v\", %s, l)", v)
 			pn("	}")
@@ -929,6 +935,12 @@ func (s *service) generateHelperFuncs(a *API) {
 			pn("		return nil, -1, err")
 			pn("	}")
 			pn("")
+			if ln == "AffinityGroups" {
+				pn("	// This is needed because of a bug with the listAffinityGroup call. It reports the")
+				pn("	// number of VirtualMachines in the groups as being the number of groups found.")
+				pn("	l.Count = len(l.%s)", ln)
+				pn("")
+			}
 			pn("	if l.Count == 0 {")
 			pn("	  return nil, l.Count, fmt.Errorf(\"No match found for %%s: %%+v\", id, l)")
 			pn("	}")


### PR DESCRIPTION
It reports the number of VirtualMachines in the groups as being the number of groups found.