### PR TITLE
Fix/improve #66

### DIFF
--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -333,7 +333,8 @@ func (p *AuthorizeSecurityGroupIngressParams) toURLValues() url.Values {
 	if v, found := p.p["usersecuritygrouplist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].account", i), k)
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].group", i), vv)
 			i++
 		}
 	}
@@ -620,7 +621,8 @@ func (p *AuthorizeSecurityGroupEgressParams) toURLValues() url.Values {
 	if v, found := p.p["usersecuritygrouplist"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].account", i), k)
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].group", i), vv)
 			i++
 		}
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -690,7 +690,8 @@ func (s *service) generateConvertCode(name, typ string) {
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].service\", i), k)", name)
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].provider\", i), vv)", name)
 		case "usersecuritygrouplist":
-			pn("	u.Set(fmt.Sprintf(\"%s[%%d].%%s\", i, k), vv)", name)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].account\", i), k)", name)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].group\", i), vv)", name)
 		default:
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", name)
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), vv)", name)


### PR DESCRIPTION
Fixing it this way makes it cleaner to use/set the `usersecuritygrouplist` in clients using this, and keeps it simular in use compared to working with `serviceproviderlist` and `tags`.

Fixes #67