### PR TITLE
change port type string

### DIFF
--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -1290,7 +1290,7 @@ type ListFirewallRulesResponse struct {
 
 type FirewallRule struct {
 	Cidrlist    string `json:"cidrlist,omitempty"`
-	Endport     int    `json:"endport,omitempty"`
+	Endport     string `json:"endport,omitempty"`
 	Fordisplay  bool   `json:"fordisplay,omitempty"`
 	Icmpcode    int    `json:"icmpcode,omitempty"`
 	Icmptype    int    `json:"icmptype,omitempty"`
@@ -1299,7 +1299,7 @@ type FirewallRule struct {
 	Ipaddressid string `json:"ipaddressid,omitempty"`
 	Networkid   string `json:"networkid,omitempty"`
 	Protocol    string `json:"protocol,omitempty"`
-	Startport   int    `json:"startport,omitempty"`
+	Startport   string `json:"startport,omitempty"`
 	State       string `json:"state,omitempty"`
 	Tags        []struct {
 		Account      string `json:"account,omitempty"`


### PR DESCRIPTION
list firewall reponse startport and endport is string


```
{
  "listfirewallrulesresponse": {
    "count": 1,
    "firewallrule": [
      {
        "cidrlist": "0.0.0.0/0",
        "endport": "22",
        "id": "1dd56bb5-0789-44b5-a6bb-7c75bd3749c0",
        "ipaddress": "210.140.85.149",
        "ipaddressid": "3f523eb4-fa78-4f77-b678-a4c6034dd905",
        "networkid": "1ba1f8b0-aed5-4c5c-8a36-5686bbfd7128",
        "protocol": "tcp",
        "startport": "22",
        "state": "Active",
        "tags": [
          {
            "key": "cloud-description",
            "value": "ssh"
          }
        ]
      }
    ]
  }
}
```