### PR TITLE
added helper function for listFirewallRules()

### DIFF
--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -1276,6 +1276,11 @@ func (s *FirewallService) ListFirewallRules(p *ListFirewallRulesParams) (*ListFi
 		return nil, err
 	}
 
+    resp, err = convertFirewallServiceResponse(resp)
+    if err != nil {
+        return nil, err
+    }
+
 	var r ListFirewallRulesResponse
 	if err := json.Unmarshal(resp, &r); err != nil {
 		return nil, err


### PR DESCRIPTION
I've added the compatibility function to listFirewallRules() to make it work with CloudStack 4.5.2 which sends startport, endport as strings and not integers.