### PR TITLE
Generation updates

### DIFF
--- a/cloudstack/APIDiscoveryService.go
+++ b/cloudstack/APIDiscoveryService.go
@@ -87,10 +87,10 @@ type Api struct {
 	} `json:"params,omitempty"`
 	Related  string `json:"related,omitempty"`
 	Response []struct {
-		Description string   `json:"description,omitempty"`
-		Name        string   `json:"name,omitempty"`
-		Response    []string `json:"response,omitempty"`
-		Type        string   `json:"type,omitempty"`
+		Description string        `json:"description,omitempty"`
+		Name        string        `json:"name,omitempty"`
+		Response    []interface{} `json:"response,omitempty"`
+		Type        string        `json:"type,omitempty"`
 	} `json:"response,omitempty"`
 	Since string `json:"since,omitempty"`
 	Type  string `json:"type,omitempty"`

--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -615,7 +615,7 @@ func (s *AddressService) GetPublicIpAddressByID(id string, opts ...OptionFunc) (
 	return nil, l.Count, fmt.Errorf("There is more then one result for PublicIpAddress UUID: %s!", id)
 }
 
-// Lists all public ip addresses
+// Lists all public IP addresses
 func (s *AddressService) ListPublicIpAddresses(p *ListPublicIpAddressesParams) (*ListPublicIpAddressesResponse, error) {
 	resp, err := s.cs.newRequest("listPublicIpAddresses", p.toURLValues())
 	if err != nil {

--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -693,21 +693,23 @@ type UpdateVMAffinityGroupResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -791,8 +793,8 @@ type UpdateVMAffinityGroupResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`

--- a/cloudstack/ConfigurationService.go
+++ b/cloudstack/ConfigurationService.go
@@ -165,6 +165,10 @@ func (p *ListConfigurationsParams) toURLValues() url.Values {
 		vv := strconv.Itoa(v.(int))
 		u.Set("pagesize", vv)
 	}
+	if v, found := p.p["showhidden"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("showhidden", vv)
+	}
 	if v, found := p.p["storageid"]; found {
 		u.Set("storageid", v.(string))
 	}
@@ -227,6 +231,14 @@ func (p *ListConfigurationsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+	return
+}
+
+func (p *ListConfigurationsParams) SetShowhidden(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["showhidden"] = v
 	return
 }
 

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -1511,15 +1511,15 @@ func (s *HostService) AddSecondaryStorage(p *AddSecondaryStorageParams) (*AddSec
 }
 
 type AddSecondaryStorageResponse struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type UpdateHostPasswordParams struct {

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -153,21 +153,23 @@ type AttachIsoResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -251,8 +253,8 @@ type AttachIsoResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -397,21 +399,23 @@ type DetachIsoResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -495,8 +499,8 @@ type DetachIsoResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -863,6 +867,7 @@ type ListIsosResponse struct {
 type Iso struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -1122,6 +1127,7 @@ func (s *ISOService) RegisterIso(p *RegisterIsoParams) (*RegisterIsoResponse, er
 type RegisterIsoResponse struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -1350,6 +1356,7 @@ func (s *ISOService) UpdateIso(p *UpdateIsoParams) (*UpdateIsoResponse, error) {
 type UpdateIsoResponse struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -1531,7 +1538,7 @@ func (s *ISOService) NewCopyIsoParams(destzoneid string, id string) *CopyIsoPara
 	return p
 }
 
-// Copies an ISO from one zone to another.
+// Copies an iso from one zone to another.
 func (s *ISOService) CopyIso(p *CopyIsoParams) (*CopyIsoResponse, error) {
 	resp, err := s.cs.newRequest("copyIso", p.toURLValues())
 	if err != nil {
@@ -1570,6 +1577,7 @@ type CopyIsoResponse struct {
 	JobID                 string            `json:"jobid,omitempty"`
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -1805,7 +1813,7 @@ func (s *ISOService) GetIsoPermissionByID(id string, opts ...OptionFunc) (*IsoPe
 	return nil, l.Count, fmt.Errorf("There is more then one result for IsoPermission UUID: %s!", id)
 }
 
-// List iso visibility and all accounts that have permissions to view this iso.
+// List ISO visibility and all accounts that have permissions to view this ISO.
 func (s *ISOService) ListIsoPermissions(p *ListIsoPermissionsParams) (*ListIsoPermissionsResponse, error) {
 	resp, err := s.cs.newRequest("listIsoPermissions", p.toURLValues())
 	if err != nil {

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -120,15 +120,15 @@ func (s *ImageStoreService) AddImageStore(p *AddImageStoreParams) (*AddImageStor
 }
 
 type AddImageStoreResponse struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type AddImageStoreS3Params struct {
@@ -298,15 +298,15 @@ func (s *ImageStoreService) AddImageStoreS3(p *AddImageStoreS3Params) (*AddImage
 }
 
 type AddImageStoreS3Response struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type ListImageStoresParams struct {
@@ -523,15 +523,15 @@ type ListImageStoresResponse struct {
 }
 
 type ImageStore struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type DeleteImageStoreParams struct {
@@ -682,15 +682,15 @@ func (s *ImageStoreService) CreateSecondaryStagingStore(p *CreateSecondaryStagin
 }
 
 type CreateSecondaryStagingStoreResponse struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type ListSecondaryStagingStoresParams struct {
@@ -907,15 +907,15 @@ type ListSecondaryStagingStoresResponse struct {
 }
 
 type SecondaryStagingStore struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type DeleteSecondaryStagingStoreParams struct {
@@ -1055,13 +1055,13 @@ func (s *ImageStoreService) UpdateCloudToUseObjectStore(p *UpdateCloudToUseObjec
 }
 
 type UpdateCloudToUseObjectStoreResponse struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }

--- a/cloudstack/InternalLBService.go
+++ b/cloudstack/InternalLBService.go
@@ -440,21 +440,23 @@ type StopInternalLoadBalancerVMResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -579,21 +581,23 @@ type StartInternalLoadBalancerVMResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -965,21 +969,23 @@ type InternalLoadBalancerVM struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -560,13 +560,13 @@ type CreateNetworkResponse struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Traffictype       string   `json:"traffictype,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Vlan              string   `json:"vlan,omitempty"`
-	Vpcid             string   `json:"vpcid,omitempty"`
-	Zoneid            string   `json:"zoneid,omitempty"`
-	Zonename          string   `json:"zonename,omitempty"`
-	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	Traffictype       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	Vlan              string        `json:"vlan,omitempty"`
+	Vpcid             string        `json:"vpcid,omitempty"`
+	Zoneid            string        `json:"zoneid,omitempty"`
+	Zonename          string        `json:"zonename,omitempty"`
+	Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 }
 
 type DeleteNetworkParams struct {
@@ -1110,13 +1110,13 @@ type Network struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Traffictype       string   `json:"traffictype,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Vlan              string   `json:"vlan,omitempty"`
-	Vpcid             string   `json:"vpcid,omitempty"`
-	Zoneid            string   `json:"zoneid,omitempty"`
-	Zonename          string   `json:"zonename,omitempty"`
-	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	Traffictype       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	Vlan              string        `json:"vlan,omitempty"`
+	Vpcid             string        `json:"vpcid,omitempty"`
+	Zoneid            string        `json:"zoneid,omitempty"`
+	Zonename          string        `json:"zonename,omitempty"`
+	Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 }
 
 type RestartNetworkParams struct {
@@ -1266,6 +1266,10 @@ func (p *UpdateNetworkParams) toURLValues() url.Values {
 	if v, found := p.p["displaytext"]; found {
 		u.Set("displaytext", v.(string))
 	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
 	if v, found := p.p["guestvmcidr"]; found {
 		u.Set("guestvmcidr", v.(string))
 	}
@@ -1280,6 +1284,10 @@ func (p *UpdateNetworkParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["networkofferingid"]; found {
 		u.Set("networkofferingid", v.(string))
+	}
+	if v, found := p.p["updateinsequence"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("updateinsequence", vv)
 	}
 	return u
 }
@@ -1313,6 +1321,14 @@ func (p *UpdateNetworkParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
 	return
 }
 
@@ -1353,6 +1369,14 @@ func (p *UpdateNetworkParams) SetNetworkofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkofferingid"] = v
+	return
+}
+
+func (p *UpdateNetworkParams) SetUpdateinsequence(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["updateinsequence"] = v
 	return
 }
 
@@ -1470,13 +1494,13 @@ type UpdateNetworkResponse struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Traffictype       string   `json:"traffictype,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Vlan              string   `json:"vlan,omitempty"`
-	Vpcid             string   `json:"vpcid,omitempty"`
-	Zoneid            string   `json:"zoneid,omitempty"`
-	Zonename          string   `json:"zonename,omitempty"`
-	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	Traffictype       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	Vlan              string        `json:"vlan,omitempty"`
+	Vpcid             string        `json:"vpcid,omitempty"`
+	Zoneid            string        `json:"zoneid,omitempty"`
+	Zonename          string        `json:"zonename,omitempty"`
+	Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 }
 
 type CreatePhysicalNetworkParams struct {
@@ -3267,13 +3291,13 @@ type PaloAltoFirewallNetwork struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Traffictype       string   `json:"traffictype,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Vlan              string   `json:"vlan,omitempty"`
-	Vpcid             string   `json:"vpcid,omitempty"`
-	Zoneid            string   `json:"zoneid,omitempty"`
-	Zonename          string   `json:"zonename,omitempty"`
-	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	Traffictype       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	Vlan              string        `json:"vlan,omitempty"`
+	Vpcid             string        `json:"vpcid,omitempty"`
+	Zoneid            string        `json:"zoneid,omitempty"`
+	Zonename          string        `json:"zonename,omitempty"`
+	Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 }
 
 type ListNetscalerLoadBalancerNetworksParams struct {
@@ -3469,13 +3493,13 @@ type NetscalerLoadBalancerNetwork struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Traffictype       string   `json:"traffictype,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Vlan              string   `json:"vlan,omitempty"`
-	Vpcid             string   `json:"vpcid,omitempty"`
-	Zoneid            string   `json:"zoneid,omitempty"`
-	Zonename          string   `json:"zonename,omitempty"`
-	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	Traffictype       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	Vlan              string        `json:"vlan,omitempty"`
+	Vpcid             string        `json:"vpcid,omitempty"`
+	Zoneid            string        `json:"zoneid,omitempty"`
+	Zonename          string        `json:"zonename,omitempty"`
+	Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 }
 
 type ListNiciraNvpDeviceNetworksParams struct {
@@ -3671,13 +3695,13 @@ type NiciraNvpDeviceNetwork struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Traffictype       string   `json:"traffictype,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Vlan              string   `json:"vlan,omitempty"`
-	Vpcid             string   `json:"vpcid,omitempty"`
-	Zoneid            string   `json:"zoneid,omitempty"`
-	Zonename          string   `json:"zonename,omitempty"`
-	Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+	Traffictype       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	Vlan              string        `json:"vlan,omitempty"`
+	Vpcid             string        `json:"vpcid,omitempty"`
+	Zoneid            string        `json:"zoneid,omitempty"`
+	Zonename          string        `json:"zonename,omitempty"`
+	Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 }
 
 type ListNetworkIsolationMethodsParams struct {

--- a/cloudstack/NicService.go
+++ b/cloudstack/NicService.go
@@ -305,21 +305,23 @@ type UpdateVmNicIpResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -403,8 +405,8 @@ type UpdateVmNicIpResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -554,21 +556,23 @@ type ListNicsResponse struct {
 }
 
 type Nic struct {
-	Broadcasturi string `json:"broadcasturi,omitempty"`
-	Deviceid     string `json:"deviceid,omitempty"`
-	Gateway      string `json:"gateway,omitempty"`
-	Id           string `json:"id,omitempty"`
-	Ip6address   string `json:"ip6address,omitempty"`
-	Ip6cidr      string `json:"ip6cidr,omitempty"`
-	Ip6gateway   string `json:"ip6gateway,omitempty"`
-	Ipaddress    string `json:"ipaddress,omitempty"`
-	Isdefault    bool   `json:"isdefault,omitempty"`
-	Isolationuri string `json:"isolationuri,omitempty"`
-	Macaddress   string `json:"macaddress,omitempty"`
-	Netmask      string `json:"netmask,omitempty"`
-	Networkid    string `json:"networkid,omitempty"`
-	Networkname  string `json:"networkname,omitempty"`
-	Secondaryip  []struct {
+	Broadcasturi         string `json:"broadcasturi,omitempty"`
+	Deviceid             string `json:"deviceid,omitempty"`
+	Gateway              string `json:"gateway,omitempty"`
+	Id                   string `json:"id,omitempty"`
+	Ip6address           string `json:"ip6address,omitempty"`
+	Ip6cidr              string `json:"ip6cidr,omitempty"`
+	Ip6gateway           string `json:"ip6gateway,omitempty"`
+	Ipaddress            string `json:"ipaddress,omitempty"`
+	Isdefault            bool   `json:"isdefault,omitempty"`
+	Isolationuri         string `json:"isolationuri,omitempty"`
+	Macaddress           string `json:"macaddress,omitempty"`
+	Netmask              string `json:"netmask,omitempty"`
+	Networkid            string `json:"networkid,omitempty"`
+	Networkname          string `json:"networkname,omitempty"`
+	Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+	Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+	Secondaryip          []struct {
 		Id        string `json:"id,omitempty"`
 		Ipaddress string `json:"ipaddress,omitempty"`
 	} `json:"secondaryip,omitempty"`

--- a/cloudstack/NiciraNVPService.go
+++ b/cloudstack/NiciraNVPService.go
@@ -34,6 +34,9 @@ func (p *AddNiciraNvpDeviceParams) toURLValues() url.Values {
 	if v, found := p.p["hostname"]; found {
 		u.Set("hostname", v.(string))
 	}
+	if v, found := p.p["l2gatewayserviceuuid"]; found {
+		u.Set("l2gatewayserviceuuid", v.(string))
+	}
 	if v, found := p.p["l3gatewayserviceuuid"]; found {
 		u.Set("l3gatewayserviceuuid", v.(string))
 	}
@@ -57,6 +60,14 @@ func (p *AddNiciraNvpDeviceParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
+	return
+}
+
+func (p *AddNiciraNvpDeviceParams) SetL2gatewayserviceuuid(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["l2gatewayserviceuuid"] = v
 	return
 }
 
@@ -151,6 +162,7 @@ func (s *NiciraNVPService) AddNiciraNvpDevice(p *AddNiciraNvpDeviceParams) (*Add
 type AddNiciraNvpDeviceResponse struct {
 	JobID                string `json:"jobid,omitempty"`
 	Hostname             string `json:"hostname,omitempty"`
+	L2gatewayserviceuuid string `json:"l2gatewayserviceuuid,omitempty"`
 	L3gatewayserviceuuid string `json:"l3gatewayserviceuuid,omitempty"`
 	Niciradevicename     string `json:"niciradevicename,omitempty"`
 	Nvpdeviceid          string `json:"nvpdeviceid,omitempty"`
@@ -326,6 +338,7 @@ type ListNiciraNvpDevicesResponse struct {
 
 type NiciraNvpDevice struct {
 	Hostname             string `json:"hostname,omitempty"`
+	L2gatewayserviceuuid string `json:"l2gatewayserviceuuid,omitempty"`
 	L3gatewayserviceuuid string `json:"l3gatewayserviceuuid,omitempty"`
 	Niciradevicename     string `json:"niciradevicename,omitempty"`
 	Nvpdeviceid          string `json:"nvpdeviceid,omitempty"`

--- a/cloudstack/RouterService.go
+++ b/cloudstack/RouterService.go
@@ -119,21 +119,23 @@ type StartRouterResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -258,21 +260,23 @@ type RebootRouterResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -409,21 +413,23 @@ type StopRouterResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -548,21 +554,23 @@ type DestroyRouterResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -678,21 +686,23 @@ type ChangeServiceForRouterResponse struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -1086,21 +1096,23 @@ type Router struct {
 	Name                string `json:"name,omitempty"`
 	Networkdomain       string `json:"networkdomain,omitempty"`
 	Nic                 []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`

--- a/cloudstack/SSHService.go
+++ b/cloudstack/SSHService.go
@@ -184,21 +184,23 @@ type ResetSSHKeyForVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -282,8 +284,8 @@ type ResetSSHKeyForVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`

--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -218,8 +218,8 @@ type CreateSecurityGroupResponse struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-	Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+	Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 }
 
 type DeleteSecurityGroupParams struct {
@@ -1238,6 +1238,6 @@ type SecurityGroup struct {
 		Resourcetype string `json:"resourcetype,omitempty"`
 		Value        string `json:"value,omitempty"`
 	} `json:"tags,omitempty"`
-	Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-	Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+	Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+	Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 }

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -1677,21 +1677,23 @@ type RevertToVMSnapshotResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -1775,8 +1777,8 @@ type RevertToVMSnapshotResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`

--- a/cloudstack/SwiftService.go
+++ b/cloudstack/SwiftService.go
@@ -104,15 +104,15 @@ func (s *SwiftService) AddSwift(p *AddSwiftParams) (*AddSwiftResponse, error) {
 }
 
 type AddSwiftResponse struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }
 
 type ListSwiftsParams struct {
@@ -239,13 +239,13 @@ type ListSwiftsResponse struct {
 }
 
 type Swift struct {
-	Details      []string `json:"details,omitempty"`
-	Id           string   `json:"id,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Providername string   `json:"providername,omitempty"`
-	Scope        string   `json:"scope,omitempty"`
-	Url          string   `json:"url,omitempty"`
-	Zoneid       string   `json:"zoneid,omitempty"`
-	Zonename     string   `json:"zonename,omitempty"`
+	Details      []interface{} `json:"details,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	Providername string        `json:"providername,omitempty"`
+	Scope        string        `json:"scope,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Zoneid       string        `json:"zoneid,omitempty"`
+	Zonename     string        `json:"zonename,omitempty"`
 }

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -272,6 +272,7 @@ type CreateTemplateResponse struct {
 	JobID                 string            `json:"jobid,omitempty"`
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -624,6 +625,7 @@ type RegisterTemplateResponse struct {
 type RegisterTemplate struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -852,6 +854,7 @@ func (s *TemplateService) UpdateTemplate(p *UpdateTemplateParams) (*UpdateTempla
 type UpdateTemplateResponse struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -993,6 +996,7 @@ type CopyTemplateResponse struct {
 	JobID                 string            `json:"jobid,omitempty"`
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -1424,6 +1428,7 @@ type ListTemplatesResponse struct {
 type Template struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`
@@ -1879,6 +1884,7 @@ func (s *TemplateService) PrepareTemplate(p *PrepareTemplateParams) (*PrepareTem
 type PrepareTemplateResponse struct {
 	Account               string            `json:"account,omitempty"`
 	Accountid             string            `json:"accountid,omitempty"`
+	Bits                  int               `json:"bits,omitempty"`
 	Bootable              bool              `json:"bootable,omitempty"`
 	Checksum              string            `json:"checksum,omitempty"`
 	Created               string            `json:"created,omitempty"`

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -391,6 +391,7 @@ type TrafficType struct {
 	Physicalnetworkid            string   `json:"physicalnetworkid,omitempty"`
 	Servicelist                  []string `json:"servicelist,omitempty"`
 	State                        string   `json:"state,omitempty"`
+	Traffictype                  string   `json:"traffictype,omitempty"`
 }
 
 type UpdateTrafficTypeParams struct {

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -288,13 +288,13 @@ type CreateVPCResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Traffictype       string   `json:"traffictype,omitempty"`
-		Type              string   `json:"type,omitempty"`
-		Vlan              string   `json:"vlan,omitempty"`
-		Vpcid             string   `json:"vpcid,omitempty"`
-		Zoneid            string   `json:"zoneid,omitempty"`
-		Zonename          string   `json:"zonename,omitempty"`
-		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+		Traffictype       string        `json:"traffictype,omitempty"`
+		Type              string        `json:"type,omitempty"`
+		Vlan              string        `json:"vlan,omitempty"`
+		Vpcid             string        `json:"vpcid,omitempty"`
+		Zoneid            string        `json:"zoneid,omitempty"`
+		Zonename          string        `json:"zonename,omitempty"`
+		Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 	} `json:"network,omitempty"`
 	Networkdomain      string `json:"networkdomain,omitempty"`
 	Project            string `json:"project,omitempty"`
@@ -761,13 +761,13 @@ type VPC struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Traffictype       string   `json:"traffictype,omitempty"`
-		Type              string   `json:"type,omitempty"`
-		Vlan              string   `json:"vlan,omitempty"`
-		Vpcid             string   `json:"vpcid,omitempty"`
-		Zoneid            string   `json:"zoneid,omitempty"`
-		Zonename          string   `json:"zonename,omitempty"`
-		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+		Traffictype       string        `json:"traffictype,omitempty"`
+		Type              string        `json:"type,omitempty"`
+		Vlan              string        `json:"vlan,omitempty"`
+		Vpcid             string        `json:"vpcid,omitempty"`
+		Zoneid            string        `json:"zoneid,omitempty"`
+		Zonename          string        `json:"zonename,omitempty"`
+		Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 	} `json:"network,omitempty"`
 	Networkdomain      string `json:"networkdomain,omitempty"`
 	Project            string `json:"project,omitempty"`
@@ -1071,13 +1071,13 @@ type UpdateVPCResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Traffictype       string   `json:"traffictype,omitempty"`
-		Type              string   `json:"type,omitempty"`
-		Vlan              string   `json:"vlan,omitempty"`
-		Vpcid             string   `json:"vpcid,omitempty"`
-		Zoneid            string   `json:"zoneid,omitempty"`
-		Zonename          string   `json:"zonename,omitempty"`
-		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+		Traffictype       string        `json:"traffictype,omitempty"`
+		Type              string        `json:"type,omitempty"`
+		Vlan              string        `json:"vlan,omitempty"`
+		Vpcid             string        `json:"vpcid,omitempty"`
+		Zoneid            string        `json:"zoneid,omitempty"`
+		Zonename          string        `json:"zonename,omitempty"`
+		Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 	} `json:"network,omitempty"`
 	Networkdomain      string `json:"networkdomain,omitempty"`
 	Project            string `json:"project,omitempty"`
@@ -1292,13 +1292,13 @@ type RestartVPCResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Traffictype       string   `json:"traffictype,omitempty"`
-		Type              string   `json:"type,omitempty"`
-		Vlan              string   `json:"vlan,omitempty"`
-		Vpcid             string   `json:"vpcid,omitempty"`
-		Zoneid            string   `json:"zoneid,omitempty"`
-		Zonename          string   `json:"zonename,omitempty"`
-		Zonesnetworkspans []string `json:"zonesnetworkspans,omitempty"`
+		Traffictype       string        `json:"traffictype,omitempty"`
+		Type              string        `json:"type,omitempty"`
+		Vlan              string        `json:"vlan,omitempty"`
+		Vpcid             string        `json:"vpcid,omitempty"`
+		Zoneid            string        `json:"zoneid,omitempty"`
+		Zonename          string        `json:"zonename,omitempty"`
+		Zonesnetworkspans []interface{} `json:"zonesnetworkspans,omitempty"`
 	} `json:"network,omitempty"`
 	Networkdomain      string `json:"networkdomain,omitempty"`
 	Project            string `json:"project,omitempty"`

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -99,6 +99,9 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["keypair"]; found {
 		u.Set("keypair", v.(string))
 	}
+	if v, found := p.p["macaddress"]; found {
+		u.Set("macaddress", v.(string))
+	}
 	if v, found := p.p["name"]; found {
 		u.Set("name", v.(string))
 	}
@@ -285,6 +288,14 @@ func (p *DeployVirtualMachineParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
+	return
+}
+
+func (p *DeployVirtualMachineParams) SetMacaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["macaddress"] = v
 	return
 }
 
@@ -480,21 +491,23 @@ type DeployVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -578,8 +591,8 @@ type DeployVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -651,7 +664,7 @@ func (s *VirtualMachineService) NewDestroyVirtualMachineParams(id string) *Destr
 	return p
 }
 
-// Destroys a virtual machine.
+// Destroys a virtual machine. Once destroyed, only the administrator can recover it.
 func (s *VirtualMachineService) DestroyVirtualMachine(p *DestroyVirtualMachineParams) (*DestroyVirtualMachineResponse, error) {
 	resp, err := s.cs.newRequest("destroyVirtualMachine", p.toURLValues())
 	if err != nil {
@@ -736,21 +749,23 @@ type DestroyVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -834,8 +849,8 @@ type DestroyVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -980,21 +995,23 @@ type RebootVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -1078,8 +1095,8 @@ type RebootVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -1246,21 +1263,23 @@ type StartVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -1344,8 +1363,8 @@ type StartVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -1502,21 +1521,23 @@ type StopVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -1600,8 +1621,8 @@ type StopVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -1746,21 +1767,23 @@ type ResetPasswordForVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -1844,8 +1867,8 @@ type ResetPasswordForVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -2097,21 +2120,23 @@ type UpdateVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -2195,8 +2220,8 @@ type UpdateVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -2748,21 +2773,23 @@ type VirtualMachine struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -2846,8 +2873,8 @@ type VirtualMachine struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -3054,21 +3081,23 @@ type RestoreVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -3152,8 +3181,8 @@ type RestoreVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -3304,21 +3333,23 @@ type ChangeServiceForVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -3402,8 +3433,8 @@ type ChangeServiceForVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -3670,21 +3701,23 @@ type AssignVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -3768,8 +3801,8 @@ type AssignVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -3936,21 +3969,23 @@ type MigrateVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -4034,8 +4069,8 @@ type MigrateVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -4208,21 +4243,23 @@ type MigrateVirtualMachineWithVolumeResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -4306,8 +4343,8 @@ type MigrateVirtualMachineWithVolumeResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -4431,21 +4468,23 @@ type RecoverVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -4529,8 +4568,8 @@ type RecoverVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -4694,6 +4733,9 @@ func (p *AddNicToVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["ipaddress"]; found {
 		u.Set("ipaddress", v.(string))
 	}
+	if v, found := p.p["macaddress"]; found {
+		u.Set("macaddress", v.(string))
+	}
 	if v, found := p.p["networkid"]; found {
 		u.Set("networkid", v.(string))
 	}
@@ -4708,6 +4750,14 @@ func (p *AddNicToVirtualMachineParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+	return
+}
+
+func (p *AddNicToVirtualMachineParams) SetMacaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["macaddress"] = v
 	return
 }
 
@@ -4822,21 +4872,23 @@ type AddNicToVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -4920,8 +4972,8 @@ type AddNicToVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -5078,21 +5130,23 @@ type RemoveNicFromVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -5176,8 +5230,8 @@ type RemoveNicFromVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -5334,21 +5388,23 @@ type UpdateDefaultNicForVirtualMachineResponse struct {
 	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
 	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Deviceid     string `json:"deviceid,omitempty"`
-		Gateway      string `json:"gateway,omitempty"`
-		Id           string `json:"id,omitempty"`
-		Ip6address   string `json:"ip6address,omitempty"`
-		Ip6cidr      string `json:"ip6cidr,omitempty"`
-		Ip6gateway   string `json:"ip6gateway,omitempty"`
-		Ipaddress    string `json:"ipaddress,omitempty"`
-		Isdefault    bool   `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress   string `json:"macaddress,omitempty"`
-		Netmask      string `json:"netmask,omitempty"`
-		Networkid    string `json:"networkid,omitempty"`
-		Networkname  string `json:"networkname,omitempty"`
-		Secondaryip  []struct {
+		Broadcasturi         string `json:"broadcasturi,omitempty"`
+		Deviceid             string `json:"deviceid,omitempty"`
+		Gateway              string `json:"gateway,omitempty"`
+		Id                   string `json:"id,omitempty"`
+		Ip6address           string `json:"ip6address,omitempty"`
+		Ip6cidr              string `json:"ip6cidr,omitempty"`
+		Ip6gateway           string `json:"ip6gateway,omitempty"`
+		Ipaddress            string `json:"ipaddress,omitempty"`
+		Isdefault            bool   `json:"isdefault,omitempty"`
+		Isolationuri         string `json:"isolationuri,omitempty"`
+		Macaddress           string `json:"macaddress,omitempty"`
+		Netmask              string `json:"netmask,omitempty"`
+		Networkid            string `json:"networkid,omitempty"`
+		Networkname          string `json:"networkname,omitempty"`
+		Nsxlogicalswitch     string `json:"nsxlogicalswitch,omitempty"`
+		Nsxlogicalswitchport string `json:"nsxlogicalswitchport,omitempty"`
+		Secondaryip          []struct {
 			Id        string `json:"id,omitempty"`
 			Ipaddress string `json:"ipaddress,omitempty"`
 		} `json:"secondaryip,omitempty"`
@@ -5432,8 +5488,8 @@ type UpdateDefaultNicForVirtualMachineResponse struct {
 			Resourcetype string `json:"resourcetype,omitempty"`
 			Value        string `json:"value,omitempty"`
 		} `json:"tags,omitempty"`
-		Virtualmachinecount int      `json:"virtualmachinecount,omitempty"`
-		Virtualmachineids   []string `json:"virtualmachineids,omitempty"`
+		Virtualmachinecount int           `json:"virtualmachinecount,omitempty"`
+		Virtualmachineids   []interface{} `json:"virtualmachineids,omitempty"`
 	} `json:"securitygroup,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`


### PR DESCRIPTION
Hey there,

First thanks a bunch for building this package, made for a great foundation for many internal projects at my company.

There are a few things, however that we needed that the base package did not provide that I hope others will find useful:

- Allowing generation based on local "listApis" response
- Adding flag to prevent ",omitempty" on generated response models
- Changing "set" type from `[]string` to `[]interface`
- Adding "massageServices" function to facilitate manual cleanup of
  somewhat...loose listApis response from cloudstack.
- Updating "cloudstack" package based on 4.8 api response

I'm open to discussing the implementation, but in general I feel that being able to generate the client based on a local CloudStack instance is a big win :)