### PR TITLE
Login api requires POST, store cookies

### DIFF
--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"regexp"
 	"sort"
@@ -144,8 +145,10 @@ type CloudStackClient struct {
 
 // Creates a new client for communicating with CloudStack
 func newClient(apiurl string, apikey string, secret string, async bool, verifyssl bool) *CloudStackClient {
+	jar, _ := cookiejar.New(nil)
 	cs := &CloudStackClient{
 		client: &http.Client{
+			Jar: jar,
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyssl}, // If verifyssl is true, skipping the verify should be false and vice versa
@@ -332,7 +335,7 @@ func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawM
 
 	var err error
 	var resp *http.Response
-	if !cs.HTTPGETOnly && (api == "deployVirtualMachine" || api == "updateVirtualMachine") {
+	if !cs.HTTPGETOnly && (api == "deployVirtualMachine" || api == "updateVirtualMachine" || api == "login") {
 		// The deployVirtualMachine API should be called using a POST call
 		// so we don't have to worry about the userdata size
 


### PR DESCRIPTION
The login api command requires a POST to authenticate. Also, add a cookie jar to the http client so sessions automatically work after authenticating with user/pass.