### PR TITLE
synchronous boolean response may be bool/string

### DIFF
--- a/cloudstack/AlertService.go
+++ b/cloudstack/AlertService.go
@@ -105,8 +105,8 @@ func (s *AlertService) ArchiveAlerts(p *ArchiveAlertsParams) (*ArchiveAlertsResp
 }
 
 type ArchiveAlertsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteAlertsParams struct {
@@ -190,8 +190,8 @@ func (s *AlertService) DeleteAlerts(p *DeleteAlertsParams) (*DeleteAlertsRespons
 }
 
 type DeleteAlertsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type GenerateAlertParams struct {

--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -450,8 +450,8 @@ func (s *ClusterService) DeleteCluster(p *DeleteClusterParams) (*DeleteClusterRe
 }
 
 type DeleteClusterResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DisableOutOfBandManagementForClusterParams struct {

--- a/cloudstack/DiskOfferingService.go
+++ b/cloudstack/DiskOfferingService.go
@@ -331,8 +331,8 @@ func (s *DiskOfferingService) DeleteDiskOffering(p *DeleteDiskOfferingParams) (*
 }
 
 type DeleteDiskOfferingResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListDiskOfferingsParams struct {

--- a/cloudstack/EventService.go
+++ b/cloudstack/EventService.go
@@ -105,8 +105,8 @@ func (s *EventService) ArchiveEvents(p *ArchiveEventsParams) (*ArchiveEventsResp
 }
 
 type ArchiveEventsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteEventsParams struct {
@@ -190,8 +190,8 @@ func (s *EventService) DeleteEvents(p *DeleteEventsParams) (*DeleteEventsRespons
 }
 
 type DeleteEventsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListEventTypesParams struct {

--- a/cloudstack/ExtFirewallService.go
+++ b/cloudstack/ExtFirewallService.go
@@ -167,8 +167,8 @@ func (s *ExtFirewallService) DeleteExternalFirewall(p *DeleteExternalFirewallPar
 }
 
 type DeleteExternalFirewallResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListExternalFirewallsParams struct {

--- a/cloudstack/ExtLoadBalancerService.go
+++ b/cloudstack/ExtLoadBalancerService.go
@@ -164,8 +164,8 @@ func (s *ExtLoadBalancerService) DeleteExternalLoadBalancer(p *DeleteExternalLoa
 }
 
 type DeleteExternalLoadBalancerResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListExternalLoadBalancersParams struct {

--- a/cloudstack/ExternalDeviceService.go
+++ b/cloudstack/ExternalDeviceService.go
@@ -242,8 +242,8 @@ func (s *ExternalDeviceService) DeleteCiscoAsa1000vResource(p *DeleteCiscoAsa100
 }
 
 type DeleteCiscoAsa1000vResourceResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteCiscoNexusVSMParams struct {
@@ -362,8 +362,8 @@ func (s *ExternalDeviceService) DeleteCiscoVnmcResource(p *DeleteCiscoVnmcResour
 }
 
 type DeleteCiscoVnmcResourceResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DisableCiscoNexusVSMParams struct {

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -939,8 +939,8 @@ func (s *HostService) DeleteHost(p *DeleteHostParams) (*DeleteHostResponse, erro
 }
 
 type DeleteHostResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DisableOutOfBandManagementForHostParams struct {
@@ -2502,6 +2502,6 @@ func (s *HostService) UpdateHostPassword(p *UpdateHostPasswordParams) (*UpdateHo
 }
 
 type UpdateHostPasswordResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -1886,6 +1886,6 @@ func (s *ISOService) UpdateIsoPermissions(p *UpdateIsoPermissionsParams) (*Updat
 }
 
 type UpdateIsoPermissionsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -464,8 +464,8 @@ func (s *ImageStoreService) DeleteImageStore(p *DeleteImageStoreParams) (*Delete
 }
 
 type DeleteImageStoreResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteSecondaryStagingStoreParams struct {
@@ -516,8 +516,8 @@ func (s *ImageStoreService) DeleteSecondaryStagingStore(p *DeleteSecondaryStagin
 }
 
 type DeleteSecondaryStagingStoreResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListImageStoresParams struct {

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -2354,8 +2354,8 @@ func (s *LoadBalancerService) DeleteSslCert(p *DeleteSslCertParams) (*DeleteSslC
 }
 
 type DeleteSslCertResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListF5LoadBalancersParams struct {

--- a/cloudstack/NATService.go
+++ b/cloudstack/NATService.go
@@ -402,8 +402,8 @@ func (s *NATService) EnableStaticNat(p *EnableStaticNatParams) (*EnableStaticNat
 }
 
 type EnableStaticNatResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListIpForwardingRulesParams struct {

--- a/cloudstack/NetworkDeviceService.go
+++ b/cloudstack/NetworkDeviceService.go
@@ -137,8 +137,8 @@ func (s *NetworkDeviceService) DeleteNetworkDevice(p *DeleteNetworkDeviceParams)
 }
 
 type DeleteNetworkDeviceResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListNetworkDeviceParams struct {

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -389,8 +389,8 @@ func (s *NetworkOfferingService) DeleteNetworkOffering(p *DeleteNetworkOfferingP
 }
 
 type DeleteNetworkOfferingResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListNetworkOfferingsParams struct {

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -3910,8 +3910,8 @@ func (s *NetworkService) ReleasePublicIpRange(p *ReleasePublicIpRangeParams) (*R
 }
 
 type ReleasePublicIpRangeResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type RestartNetworkParams struct {

--- a/cloudstack/PodService.go
+++ b/cloudstack/PodService.go
@@ -313,8 +313,8 @@ func (s *PodService) DeletePod(p *DeletePodParams) (*DeletePodResponse, error) {
 }
 
 type DeletePodResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListDedicatedPodsParams struct {

--- a/cloudstack/PoolService.go
+++ b/cloudstack/PoolService.go
@@ -298,8 +298,8 @@ func (s *PoolService) DeleteStoragePool(p *DeleteStoragePoolParams) (*DeleteStor
 }
 
 type DeleteStoragePoolResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type FindStoragePoolsForMigrationParams struct {

--- a/cloudstack/RegionService.go
+++ b/cloudstack/RegionService.go
@@ -257,8 +257,8 @@ func (s *RegionService) RemoveRegion(p *RemoveRegionParams) (*RemoveRegionRespon
 }
 
 type RemoveRegionResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type UpdateRegionParams struct {

--- a/cloudstack/RoleService.go
+++ b/cloudstack/RoleService.go
@@ -239,8 +239,8 @@ func (s *RoleService) DeleteRole(p *DeleteRoleParams) (*DeleteRoleResponse, erro
 }
 
 type DeleteRoleResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteRolePermissionParams struct {
@@ -291,8 +291,8 @@ func (s *RoleService) DeleteRolePermission(p *DeleteRolePermissionParams) (*Dele
 }
 
 type DeleteRolePermissionResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListRolePermissionsParams struct {
@@ -599,8 +599,8 @@ func (s *RoleService) UpdateRole(p *UpdateRoleParams) (*UpdateRoleResponse, erro
 }
 
 type UpdateRoleResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type UpdateRolePermissionParams struct {
@@ -664,6 +664,6 @@ func (s *RoleService) UpdateRolePermission(p *UpdateRolePermissionParams) (*Upda
 }
 
 type UpdateRolePermissionResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }

--- a/cloudstack/SSHService.go
+++ b/cloudstack/SSHService.go
@@ -191,8 +191,8 @@ func (s *SSHService) DeleteSSHKeyPair(p *DeleteSSHKeyPairParams) (*DeleteSSHKeyP
 }
 
 type DeleteSSHKeyPairResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListSSHKeyPairsParams struct {

--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -767,8 +767,8 @@ func (s *SecurityGroupService) DeleteSecurityGroup(p *DeleteSecurityGroupParams)
 }
 
 type DeleteSecurityGroupResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListSecurityGroupsParams struct {

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -454,8 +454,8 @@ func (s *ServiceOfferingService) DeleteServiceOffering(p *DeleteServiceOfferingP
 }
 
 type DeleteServiceOfferingResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListServiceOfferingsParams struct {

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -559,8 +559,8 @@ func (s *SnapshotService) DeleteSnapshotPolicies(p *DeleteSnapshotPoliciesParams
 }
 
 type DeleteSnapshotPoliciesResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteVMSnapshotParams struct {

--- a/cloudstack/StratosphereSSPService.go
+++ b/cloudstack/StratosphereSSPService.go
@@ -180,6 +180,6 @@ func (s *StratosphereSSPService) DeleteStratosphereSsp(p *DeleteStratosphereSspP
 }
 
 type DeleteStratosphereSspResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -2155,8 +2155,8 @@ func (s *TemplateService) UpdateTemplatePermissions(p *UpdateTemplatePermissions
 }
 
 type UpdateTemplatePermissionsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type UpgradeRouterTemplateParams struct {

--- a/cloudstack/UCSService.go
+++ b/cloudstack/UCSService.go
@@ -273,8 +273,8 @@ func (s *UCSService) DeleteUcsManager(p *DeleteUcsManagerParams) (*DeleteUcsMana
 }
 
 type DeleteUcsManagerResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListUcsBladesParams struct {

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -328,8 +328,8 @@ func (s *UsageService) DeleteTrafficMonitor(p *DeleteTrafficMonitorParams) (*Del
 }
 
 type DeleteTrafficMonitorResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DeleteTrafficTypeParams struct {
@@ -471,8 +471,8 @@ func (s *UsageService) GenerateUsageRecords(p *GenerateUsageRecordsParams) (*Gen
 }
 
 type GenerateUsageRecordsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListTrafficMonitorsParams struct {
@@ -1086,8 +1086,8 @@ func (s *UsageService) RemoveRawUsageRecords(p *RemoveRawUsageRecordsParams) (*R
 }
 
 type RemoveRawUsageRecordsResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type UpdateTrafficTypeParams struct {

--- a/cloudstack/UserService.go
+++ b/cloudstack/UserService.go
@@ -239,8 +239,8 @@ func (s *UserService) DeleteUser(p *DeleteUserParams) (*DeleteUserResponse, erro
 }
 
 type DeleteUserResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DisableUserParams struct {

--- a/cloudstack/VLANService.go
+++ b/cloudstack/VLANService.go
@@ -424,8 +424,8 @@ func (s *VLANService) DeleteVlanIpRange(p *DeleteVlanIpRangeParams) (*DeleteVlan
 }
 
 type DeleteVlanIpRangeResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListDedicatedGuestVlanRangesParams struct {

--- a/cloudstack/VMGroupService.go
+++ b/cloudstack/VMGroupService.go
@@ -163,8 +163,8 @@ func (s *VMGroupService) DeleteInstanceGroup(p *DeleteInstanceGroupParams) (*Del
 }
 
 type DeleteInstanceGroupResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type ListInstanceGroupsParams struct {

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -473,8 +473,8 @@ func (s *VolumeService) DeleteVolume(p *DeleteVolumeParams) (*DeleteVolumeRespon
 }
 
 type DeleteVolumeResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DetachVolumeParams struct {

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -515,8 +515,8 @@ func (s *ZoneService) DeleteZone(p *DeleteZoneParams) (*DeleteZoneResponse, erro
 }
 
 type DeleteZoneResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type DisableOutOfBandManagementForZoneParams struct {
@@ -1348,8 +1348,8 @@ func (s *ZoneService) RemoveVmwareDc(p *RemoveVmwareDcParams) (*RemoveVmwareDcRe
 }
 
 type RemoveVmwareDcResponse struct {
-	Displaytext string `json:"displaytext"`
-	Success     string `json:"success"`
+	Displaytext string          `json:"displaytext"`
+	Success     json.RawMessage `json:"success"`
 }
 
 type UpdateZoneParams struct {

--- a/generate/README.md
+++ b/generate/README.md
@@ -1,0 +1,7 @@
+How to regenerate the things
+
+```
+$ go get golang.org/x/tools/cmd/goimports
+$ go build github.com/xanzy/go-cloudstack/generate
+$ ./generate
+```

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1294,7 +1294,7 @@ func (s *service) recusiveGenerateResponseType(resp APIResponses, async bool) (o
 					if async {
 						pn("%s bool `json:\"%s\"`", capitalize(r.Name), r.Name)
 					} else {
-						pn("%s string `json:\"%s\"`", capitalize(r.Name), r.Name)
+						pn("%s json.RawMessage `json:\"%s\"`", capitalize(r.Name), r.Name)
 					}
 				} else {
 					pn("%s %s `json:\"%s\"`", capitalize(r.Name), mapType(r.Type), r.Name)


### PR DESCRIPTION
all the sync requests will be correct and return a true _boolean_ type rather than a string containing `"true"`, `"false"`. As the status code is usually used rather than this value, it shouldn't break much things.

cf. https://github.com/apache/cloudstack/pull/2428