### PR TITLE
Various improvements and fixes

### DIFF
--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -118,7 +118,7 @@ type AddGuestOsResponse struct {
 	JobID         string `json:"jobid"`
 	Description   string `json:"description"`
 	Id            string `json:"id"`
-	Isuserdefined string `json:"isuserdefined"`
+	Isuserdefined CSBool `json:"isuserdefined"`
 	Oscategoryid  string `json:"oscategoryid"`
 }
 
@@ -240,7 +240,7 @@ type AddGuestOsMappingResponse struct {
 	Hypervisor          string `json:"hypervisor"`
 	Hypervisorversion   string `json:"hypervisorversion"`
 	Id                  string `json:"id"`
-	Isuserdefined       string `json:"isuserdefined"`
+	Isuserdefined       CSBool `json:"isuserdefined"`
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
 	Ostypeid            string `json:"ostypeid"`
@@ -402,7 +402,7 @@ type GuestOsMapping struct {
 	Hypervisor          string `json:"hypervisor"`
 	Hypervisorversion   string `json:"hypervisorversion"`
 	Id                  string `json:"id"`
-	Isuserdefined       string `json:"isuserdefined"`
+	Isuserdefined       CSBool `json:"isuserdefined"`
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
 	Ostypeid            string `json:"ostypeid"`
@@ -737,7 +737,7 @@ type ListOsTypesResponse struct {
 type OsType struct {
 	Description   string `json:"description"`
 	Id            string `json:"id"`
-	Isuserdefined string `json:"isuserdefined"`
+	Isuserdefined CSBool `json:"isuserdefined"`
 	Oscategoryid  string `json:"oscategoryid"`
 }
 
@@ -960,7 +960,7 @@ type UpdateGuestOsResponse struct {
 	JobID         string `json:"jobid"`
 	Description   string `json:"description"`
 	Id            string `json:"id"`
-	Isuserdefined string `json:"isuserdefined"`
+	Isuserdefined CSBool `json:"isuserdefined"`
 	Oscategoryid  string `json:"oscategoryid"`
 }
 
@@ -1048,7 +1048,7 @@ type UpdateGuestOsMappingResponse struct {
 	Hypervisor          string `json:"hypervisor"`
 	Hypervisorversion   string `json:"hypervisorversion"`
 	Id                  string `json:"id"`
-	Isuserdefined       string `json:"isuserdefined"`
+	Isuserdefined       CSBool `json:"isuserdefined"`
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
 	Ostypeid            string `json:"ostypeid"`

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -470,6 +470,14 @@ func (p *DeleteTemplateParams) SetZoneid(v string) {
 	return
 }
 
+func (p *DeleteTemplateParams) SetForced(b bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = b
+	return
+}
+
 // You should always use this function to get a new DeleteTemplateParams instance,
 // as then you are sure you have configured all required params
 func (s *TemplateService) NewDeleteTemplateParams(id string) *DeleteTemplateParams {
@@ -911,12 +919,14 @@ func (s *TemplateService) GetUploadParamsForTemplate(p *GetUploadParamsForTempla
 		return nil, err
 	}
 
-	var r GetUploadParamsForTemplateResponse
+	var r struct {
+		Response GetUploadParamsForTemplateResponse `json:"getuploadparams"`
+	}
 	if err := json.Unmarshal(resp, &r); err != nil {
 		return nil, err
 	}
 
-	return &r, nil
+	return &r.Response, nil
 }
 
 type GetUploadParamsForTemplateResponse struct {

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-
 package cloudstack
 
 import (
@@ -848,7 +847,8 @@ type CleanVMReservationsResponse struct {
 }
 
 type DeployVirtualMachineParams struct {
-	p map[string]interface{}
+	p           map[string]interface{}
+	iptonetlist []map[string]string
 }
 
 func (p *DeployVirtualMachineParams) toURLValues() url.Values {
@@ -908,12 +908,11 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["ipaddress"]; found {
 		u.Set("ipaddress", v.(string))
 	}
-	if v, found := p.p["iptonetworklist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("iptonetworklist[%d].key", i), k)
-			u.Set(fmt.Sprintf("iptonetworklist[%d].value", i), vv)
-			i++
+	if p.iptonetlist != nil && len(p.iptonetlist) > 0 {
+		for i, m := range p.iptonetlist {
+			for k, v := range m {
+				u.Set(fmt.Sprintf("iptonetworklist[%d].%s", i, k), v)
+			}
 		}
 	}
 	if v, found := p.p["keyboard"]; found {
@@ -1087,11 +1086,11 @@ func (p *DeployVirtualMachineParams) SetIpaddress(v string) {
 	return
 }
 
-func (p *DeployVirtualMachineParams) SetIptonetworklist(v map[string]string) {
-	if p.p == nil {
-		p.p = make(map[string]interface{})
+func (p *DeployVirtualMachineParams) AddIptonetworklist(v map[string]string) {
+	if p.iptonetlist == nil {
+		p.iptonetlist = make([]map[string]string, 0)
 	}
-	p.p["iptonetworklist"] = v
+	p.iptonetlist = append(p.iptonetlist, v)
 	return
 }
 

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -143,6 +144,22 @@ type CloudStackClient struct {
 	Zone                *ZoneService
 }
 
+type CSBool bool
+
+func (c CSBool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(bool(c))
+}
+
+func (c *CSBool) UnmarshalJSON(data []byte) error {
+	value := strings.Replace(strings.ToLower(string(data)), "\"", "", -1)
+	b, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	*c = CSBool(b)
+	return nil
+}
+
 // Creates a new client for communicating with CloudStack
 func newClient(apiurl string, apikey string, secret string, async bool, verifyssl bool) *CloudStackClient {
 	jar, _ := cookiejar.New(nil)
@@ -153,7 +170,7 @@ func newClient(apiurl string, apikey string, secret string, async bool, verifyss
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyssl}, // If verifyssl is true, skipping the verify should be false and vice versa
 			},
-			Timeout: time.Duration(60 * time.Second),
+			Timeout: time.Duration(5 * time.Minute),
 		},
 		baseURL: apiurl,
 		apiKey:  apikey,


### PR DESCRIPTION
### TemplateService

1. Proper handle of 'getUploadParamsForTemplate' response

    Despite [documentation](https://cloudstack.apache.org/api/apidocs-4.11/apis/getUploadParamsForTemplate.html), cloudstack actually returns an intermediate structure `getuploadparams` in `getUploadParamsForTemplate` reponse.

    **Affected endpoints**:
   * getUploadParamsForTemplate

2. Add missing `forced` option in deleteTemplate parameters

    **Affected endpoints**:
   * deleteTemplate

3. Handle bool instead of string in 'isuserdefined' reponse fields. 

    This breaking change was brought in cloudstack in version 4.11.1.0 as described in their [pull request](https://github.com/apache/cloudstack/pull/2632) and [release note](http://docs.cloudstack.apache.org/projects/cloudstack-release-notes/en/4.11.1.0/fixed_issues.html). The PR offers an implementation that ensure backwark compatibility with strings fields.

    **Affected endpoints**:
    * addGuestOsTemplate
    * addGuestOsMapping
    * listOfTypes
    * updateGuestOs

### VirtualMachineService

1. Handle `iptonetworklist` parameter of deployVirtualMachine as a list of properties

    As pointed out in #87, `iptonetworklist` is improperly constructed. The PR changes the attribute to a list of map which is serialized as `iptonetworklist[<index>].<key>=<value>`
  
    **Affected endpoints**:
    * deployVirtualMachine

### Other

1. Change default http timeout used in sync operations

     Default timeout of `60 seconds` can be a little low for synchroneus operations like `enableStaticNat` under heavy load. The PR changes it to `5 minues`
    
