### PR TITLE
GuestOSService: fix the Isuserdefined to bool

### DIFF
--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -256,7 +256,7 @@ type AddGuestOsMappingResponse struct {
 	Hypervisor          string `json:"hypervisor"`
 	Hypervisorversion   string `json:"hypervisorversion"`
 	Id                  string `json:"id"`
-	Isuserdefined       string `json:"isuserdefined"`
+	Isuserdefined       bool   `json:"isuserdefined"`
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
 	Ostypeid            string `json:"ostypeid"`
@@ -418,7 +418,7 @@ type GuestOsMapping struct {
 	Hypervisor          string `json:"hypervisor"`
 	Hypervisorversion   string `json:"hypervisorversion"`
 	Id                  string `json:"id"`
-	Isuserdefined       string `json:"isuserdefined"`
+	Isuserdefined       bool   `json:"isuserdefined"`
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
 	Ostypeid            string `json:"ostypeid"`
@@ -1080,7 +1080,7 @@ type UpdateGuestOsMappingResponse struct {
 	Hypervisor          string `json:"hypervisor"`
 	Hypervisorversion   string `json:"hypervisorversion"`
 	Id                  string `json:"id"`
-	Isuserdefined       string `json:"isuserdefined"`
+	Isuserdefined       bool   `json:"isuserdefined"`
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
 	Ostypeid            string `json:"ostypeid"`


### PR DESCRIPTION
This fixes issue discovered via packer:
Error retrieving UUID of OS type CentOS 7.2: json: cannot unmarshal bool into Go struct field OsType.isuserdefined of type string