### PR TITLE
Change details field encoding to match cloudstack expectations

### DIFF
--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -36,7 +36,8 @@ func (p *AddGuestOsParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}
@@ -969,7 +970,8 @@ func (p *UpdateGuestOsParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -36,7 +36,8 @@ func (p *AddImageStoreParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}
@@ -323,7 +324,8 @@ func (p *CreateSecondaryStagingStoreParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}
@@ -1045,7 +1047,8 @@ func (p *UpdateCloudToUseObjectStoreParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/cloudstack/ResourcemetadataService.go
+++ b/cloudstack/ResourcemetadataService.go
@@ -35,7 +35,8 @@ func (p *AddResourceDetailParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -1109,7 +1109,8 @@ func (p *UpdateZoneParams) toURLValues() url.Values {
 	if v, found := p.p["details"]; found {
 		i := 0
 		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
+			u.Set(fmt.Sprintf("details[%d].key", i), k)
+			u.Set(fmt.Sprintf("details[%d].value", i), vv)
 			i++
 		}
 	}


### PR DESCRIPTION
Fixes #118

How the details field must be encoded changes depending on the command implementation. Some commands allow arbitrary keys and some other commands require only 2 keys to exist ('key' and 'value') and allow a list of such key value pairs as the details field.

I wasn't able to find anything in the documentation that would make it clear which encoding was required for each command and had to look at cloudstack's code to figure this out.

Here is a list of the commands singled out in this commit and references to the required encoding in cloudstack's code:

addGuestOs
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/admin/guest/AddGuestOsCmd.java#L88-L89

updateGuestOs
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/admin/guest/UpdateGuestOsCmd.java#L80-L81

addImageStore
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/AddImageStoreCmd.java#L90-L91

createSecondaryStagingStore
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/CreateSecondaryStagingStoreCmd.java#L80

updateCloudToUseObjectStore
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/UpdateCloudToUseObjectStoreCmd.java#L84-L85

addResourceDetail
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/api/src/main/java/org/apache/cloudstack/api/command/user/volume/AddResourceDetailCmd.java#L68-L69

updateZone
https://github.com/apache/cloudstack/blob/87c43501608a1df72a2f01ed17a522233e6617b0/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java#L1866-L1867
