### PR TITLE
Present map API type in a predictable order

### DIFF
--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -128,11 +128,10 @@ func (p *CreateAccountParams) toURLValues() url.Values {
 		u.Set("account", v.(string))
 	}
 	if v, found := p.p["accountdetails"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["accountid"]; found {
@@ -1834,11 +1833,10 @@ func (p *UpdateAccountParams) toURLValues() url.Values {
 		u.Set("account", v.(string))
 	}
 	if v, found := p.p["accountdetails"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["domainid"]; found {

--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -362,11 +362,10 @@ func (p *ListPublicIpAddressesParams) toURLValues() url.Values {
 		u.Set("state", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["vlanid"]; found {

--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -332,11 +332,10 @@ func (p *CreateAutoScaleVmProfileParams) toURLValues() url.Values {
 		u.Set("autoscaleuserid", v.(string))
 	}
 	if v, found := p.p["counterparam"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("counterparam[%d].key", i), k)
-			u.Set(fmt.Sprintf("counterparam[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("counterparam[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["destroyvmgraceperiod"]; found {
@@ -2658,11 +2657,10 @@ func (p *UpdateAutoScaleVmProfileParams) toURLValues() url.Values {
 		u.Set("autoscaleuserid", v.(string))
 	}
 	if v, found := p.p["counterparam"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("counterparam[%d].key", i), k)
-			u.Set(fmt.Sprintf("counterparam[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("counterparam[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["customid"]; found {

--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -1277,11 +1277,10 @@ func (p *ListEgressFirewallRulesParams) toURLValues() url.Values {
 		u.Set("projectid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -1527,11 +1526,10 @@ func (p *ListFirewallRulesParams) toURLValues() url.Values {
 		u.Set("projectid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -1900,11 +1898,10 @@ func (p *ListPortForwardingRulesParams) toURLValues() url.Values {
 		u.Set("projectid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u

--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -34,11 +34,10 @@ func (p *AddGuestOsParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["name"]; found {
@@ -968,11 +967,10 @@ func (p *UpdateGuestOsParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["id"]; found {

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -980,11 +980,10 @@ func (p *ListIsosParams) toURLValues() url.Values {
 		u.Set("showremoved", vv)
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["zoneid"]; found {
@@ -1649,10 +1648,9 @@ func (p *UpdateIsoParams) toURLValues() url.Values {
 		u.Set("cleanupdetails", vv)
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["displaytext"]; found {

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -34,11 +34,10 @@ func (p *AddImageStoreParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["name"]; found {
@@ -322,11 +321,10 @@ func (p *CreateSecondaryStagingStoreParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["provider"]; found {
@@ -1045,11 +1043,10 @@ func (p *UpdateCloudToUseObjectStoreParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["name"]; found {

--- a/cloudstack/LDAPService.go
+++ b/cloudstack/LDAPService.go
@@ -193,11 +193,10 @@ func (p *ImportLdapUsersParams) toURLValues() url.Values {
 		u.Set("account", v.(string))
 	}
 	if v, found := p.p["accountdetails"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["accounttype"]; found {
@@ -517,11 +516,10 @@ func (p *LdapCreateAccountParams) toURLValues() url.Values {
 		u.Set("account", v.(string))
 	}
 	if v, found := p.p["accountdetails"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("accountdetails[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("accountdetails[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["accountid"]; found {

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -296,11 +296,10 @@ func (p *AssignToGlobalLoadBalancerRuleParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["gslblbruleweightsmap"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("gslblbruleweightsmap[%d].key", i), k)
-			u.Set(fmt.Sprintf("gslblbruleweightsmap[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("gslblbruleweightsmap[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["id"]; found {
@@ -401,11 +400,10 @@ func (p *AssignToLoadBalancerRuleParams) toURLValues() url.Values {
 		u.Set("virtualmachineids", vv)
 	}
 	if v, found := p.p["vmidipmap"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("vmidipmap[%d].key", i), k)
-			u.Set(fmt.Sprintf("vmidipmap[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("vmidipmap[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -1016,11 +1014,10 @@ func (p *CreateLBStickinessPolicyParams) toURLValues() url.Values {
 		u.Set("name", v.(string))
 	}
 	if v, found := p.p["param"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("param[%d].key", i), k)
-			u.Set(fmt.Sprintf("param[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("param[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -2137,11 +2134,10 @@ func (p *ListGlobalLoadBalancerRulesParams) toURLValues() url.Values {
 		u.Set("regionid", vv)
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -2926,11 +2922,10 @@ func (p *ListLoadBalancerRulesParams) toURLValues() url.Values {
 		u.Set("publicipid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["virtualmachineid"]; found {
@@ -3267,11 +3262,10 @@ func (p *ListLoadBalancersParams) toURLValues() url.Values {
 		u.Set("sourceipaddressnetworkid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -3935,11 +3929,10 @@ func (p *RemoveFromLoadBalancerRuleParams) toURLValues() url.Values {
 		u.Set("virtualmachineids", vv)
 	}
 	if v, found := p.p["vmidipmap"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("vmidipmap[%d].key", i), k)
-			u.Set(fmt.Sprintf("vmidipmap[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("vmidipmap[%d].value", i), m[k])
 		}
 	}
 	return u

--- a/cloudstack/NetworkACLService.go
+++ b/cloudstack/NetworkACLService.go
@@ -838,11 +838,10 @@ func (p *ListNetworkACLsParams) toURLValues() url.Values {
 		u.Set("protocol", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["traffictype"]; found {

--- a/cloudstack/NetworkDeviceService.go
+++ b/cloudstack/NetworkDeviceService.go
@@ -33,11 +33,10 @@ func (p *AddNetworkDeviceParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["networkdeviceparameterlist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["networkdevicetype"]; found {
@@ -185,11 +184,10 @@ func (p *ListNetworkDeviceParams) toURLValues() url.Values {
 		u.Set("keyword", v.(string))
 	}
 	if v, found := p.p["networkdeviceparameterlist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].key", i), k)
-			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("networkdeviceparameterlist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["networkdevicetype"]; found {

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -41,10 +41,9 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 		u.Set("conservemode", vv)
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["displaytext"]; found {
@@ -81,22 +80,20 @@ func (p *CreateNetworkOfferingParams) toURLValues() url.Values {
 		u.Set("networkrate", vv)
 	}
 	if v, found := p.p["servicecapabilitylist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("servicecapabilitylist[%d].key", i), k)
-			u.Set(fmt.Sprintf("servicecapabilitylist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("servicecapabilitylist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["serviceofferingid"]; found {
 		u.Set("serviceofferingid", v.(string))
 	}
 	if v, found := p.p["serviceproviderlist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
-			i++
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), m[k])
 		}
 	}
 	if v, found := p.p["specifyipranges"]; found {

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -2122,11 +2122,10 @@ func (p *ListNetworksParams) toURLValues() url.Values {
 		u.Set("supportedservices", vv)
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["traffictype"]; found {

--- a/cloudstack/PoolService.go
+++ b/cloudstack/PoolService.go
@@ -45,10 +45,9 @@ func (p *CreateStoragePoolParams) toURLValues() url.Values {
 		u.Set("clusterid", v.(string))
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["hypervisor"]; found {

--- a/cloudstack/ProjectService.go
+++ b/cloudstack/ProjectService.go
@@ -687,11 +687,10 @@ func (p *ListProjectsParams) toURLValues() url.Values {
 		u.Set("state", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u

--- a/cloudstack/ResourcemetadataService.go
+++ b/cloudstack/ResourcemetadataService.go
@@ -33,11 +33,10 @@ func (p *AddResourceDetailParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["fordisplay"]; found {

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -20,18 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 )
-
-func getSortedKeysFromMap(m map[string]string) (keys []string) {
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return
-}
 
 type CreateTagsParams struct {
 	p map[string]interface{}

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -25,6 +25,14 @@ import (
 	"strings"
 )
 
+func getSortedKeysFromMap(m map[string]string) (keys []string) {
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return
+}
+
 type CreateTagsParams struct {
 	p map[string]interface{}
 }
@@ -45,10 +53,10 @@ func (p *CreateTagsParams) toURLValues() url.Values {
 		u.Set("resourcetype", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		tags := v.(map[string]string)
-		for i, key := range getSortedKeysFromMap(tags) {
-			u.Set(fmt.Sprintf("tags[%d].key", i), key)
-			u.Set(fmt.Sprintf("tags[%d].value", i), tags[key])
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -151,10 +159,10 @@ func (p *DeleteTagsParams) toURLValues() url.Values {
 		u.Set("resourcetype", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		tags := v.(map[string]string)
-		for i, key := range getSortedKeysFromMap(tags) {
-			u.Set(fmt.Sprintf("tags[%d].key", i), key)
-			u.Set(fmt.Sprintf("tags[%d].value", i), tags[key])
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), k)
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -550,13 +558,4 @@ type Tag struct {
 	Resourceid   string `json:"resourceid"`
 	Resourcetype string `json:"resourcetype"`
 	Value        string `json:"value"`
-}
-
-func getSortedKeysFromMap(m map[string]string) []string {
-	var keys []string
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -44,11 +45,10 @@ func (p *CreateTagsParams) toURLValues() url.Values {
 		u.Set("resourcetype", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+		tags := v.(map[string]string)
+		for i, key := range getSortedKeysFromMap(tags) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), key)
+			u.Set(fmt.Sprintf("tags[%d].value", i), tags[key])
 		}
 	}
 	return u
@@ -151,11 +151,10 @@ func (p *DeleteTagsParams) toURLValues() url.Values {
 		u.Set("resourcetype", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+		tags := v.(map[string]string)
+		for i, key := range getSortedKeysFromMap(tags) {
+			u.Set(fmt.Sprintf("tags[%d].key", i), key)
+			u.Set(fmt.Sprintf("tags[%d].value", i), tags[key])
 		}
 	}
 	return u
@@ -551,4 +550,13 @@ type Tag struct {
 	Resourceid   string `json:"resourceid"`
 	Resourcetype string `json:"resourcetype"`
 	Value        string `json:"value"`
+}
+
+func getSortedKeysFromMap(m map[string]string) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -104,11 +104,10 @@ func (p *AuthorizeSecurityGroupEgressParams) toURLValues() url.Values {
 		u.Set("startport", vv)
 	}
 	if v, found := p.p["usersecuritygrouplist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].account", i), k)
-			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].group", i), vv)
-			i++
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].group", i), m[k])
 		}
 	}
 	return u
@@ -321,11 +320,10 @@ func (p *AuthorizeSecurityGroupIngressParams) toURLValues() url.Values {
 		u.Set("startport", vv)
 	}
 	if v, found := p.p["usersecuritygrouplist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].account", i), k)
-			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].group", i), vv)
-			i++
+			u.Set(fmt.Sprintf("usersecuritygrouplist[%d].group", i), m[k])
 		}
 	}
 	return u
@@ -784,11 +782,10 @@ func (p *ListSecurityGroupsParams) toURLValues() url.Values {
 		u.Set("securitygroupname", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["virtualmachineid"]; found {

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -148,11 +148,10 @@ func (p *CreateServiceOfferingParams) toURLValues() url.Values {
 		u.Set("provisioningtype", v.(string))
 	}
 	if v, found := p.p["serviceofferingdetails"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("serviceofferingdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("serviceofferingdetails[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("serviceofferingdetails[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["storagetype"]; found {

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -917,11 +917,10 @@ func (p *ListSnapshotsParams) toURLValues() url.Values {
 		u.Set("snapshottype", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["volumeid"]; found {
@@ -1270,11 +1269,10 @@ func (p *ListVMSnapshotParams) toURLValues() url.Values {
 		u.Set("state", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["virtualmachineid"]; found {

--- a/cloudstack/SystemVMService.go
+++ b/cloudstack/SystemVMService.go
@@ -34,10 +34,9 @@ func (p *ChangeServiceForSystemVmParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["id"]; found {
@@ -732,10 +731,9 @@ func (p *ScaleSystemVmParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["id"]; found {

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -213,10 +213,9 @@ func (p *CreateTemplateParams) toURLValues() url.Values {
 		u.Set("bits", vv)
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["displaytext"]; found {
@@ -761,10 +760,9 @@ func (p *GetUploadParamsForTemplateParams) toURLValues() url.Values {
 		u.Set("checksum", v.(string))
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["displaytext"]; found {
@@ -1189,11 +1187,10 @@ func (p *ListTemplatesParams) toURLValues() url.Values {
 		u.Set("showremoved", vv)
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["templatefilter"]; found {
@@ -1694,10 +1691,9 @@ func (p *RegisterTemplateParams) toURLValues() url.Values {
 		u.Set("checksum", v.(string))
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["directdownload"]; found {
@@ -2091,10 +2087,9 @@ func (p *UpdateTemplateParams) toURLValues() url.Values {
 		u.Set("cleanupdetails", vv)
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["displaytext"]; found {

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -625,22 +625,20 @@ func (p *CreateVPCOfferingParams) toURLValues() url.Values {
 		u.Set("name", v.(string))
 	}
 	if v, found := p.p["servicecapabilitylist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("servicecapabilitylist[%d].key", i), k)
-			u.Set(fmt.Sprintf("servicecapabilitylist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("servicecapabilitylist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["serviceofferingid"]; found {
 		u.Set("serviceofferingid", v.(string))
 	}
 	if v, found := p.p["serviceproviderlist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("serviceproviderlist[%d].service", i), k)
-			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), vv)
-			i++
+			u.Set(fmt.Sprintf("serviceproviderlist[%d].provider", i), m[k])
 		}
 	}
 	if v, found := p.p["supportedservices"]; found {
@@ -1342,11 +1340,10 @@ func (p *ListStaticRoutesParams) toURLValues() url.Values {
 		u.Set("projectid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["vpcid"]; found {
@@ -1855,11 +1852,10 @@ func (p *ListVPCsParams) toURLValues() url.Values {
 		u.Set("supportedservices", vv)
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["vpcofferingid"]; found {

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -34,11 +34,10 @@ func (p *AddNicToVirtualMachineParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["dhcpoptions"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("dhcpoptions[%d].key", i), k)
-			u.Set(fmt.Sprintf("dhcpoptions[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("dhcpoptions[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["ipaddress"]; found {
@@ -529,10 +528,9 @@ func (p *ChangeServiceForVirtualMachineParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["id"]; found {
@@ -811,29 +809,26 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 		u.Set("customid", v.(string))
 	}
 	if v, found := p.p["datadiskofferinglist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("datadiskofferinglist[%d].key", i), k)
-			u.Set(fmt.Sprintf("datadiskofferinglist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("datadiskofferinglist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["deploymentplanner"]; found {
 		u.Set("deploymentplanner", v.(string))
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["dhcpoptionsnetworklist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("dhcpoptionsnetworklist[%d].key", i), k)
-			u.Set(fmt.Sprintf("dhcpoptionsnetworklist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("dhcpoptionsnetworklist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["diskofferingid"]; found {
@@ -868,11 +863,10 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 		u.Set("ipaddress", v.(string))
 	}
 	if v, found := p.p["iptonetworklist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("iptonetworklist[%d].key", i), k)
-			u.Set(fmt.Sprintf("iptonetworklist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("iptonetworklist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["keyboard"]; found {
@@ -1827,11 +1821,10 @@ func (p *ListVirtualMachinesParams) toURLValues() url.Values {
 		u.Set("storageid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["templateid"]; found {
@@ -2576,11 +2569,10 @@ func (p *MigrateVirtualMachineWithVolumeParams) toURLValues() url.Values {
 		u.Set("hostid", v.(string))
 	}
 	if v, found := p.p["migrateto"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("migrateto[%d].key", i), k)
-			u.Set(fmt.Sprintf("migrateto[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("migrateto[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["virtualmachineid"]; found {
@@ -3828,10 +3820,9 @@ func (p *ScaleVirtualMachineParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["id"]; found {
@@ -4589,18 +4580,16 @@ func (p *UpdateVirtualMachineParams) toURLValues() url.Values {
 		u.Set("customid", v.(string))
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), vv)
-			i++
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["dhcpoptionsnetworklist"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("dhcpoptionsnetworklist[%d].key", i), k)
-			u.Set(fmt.Sprintf("dhcpoptionsnetworklist[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("dhcpoptionsnetworklist[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["displayname"]; found {

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -1170,11 +1170,10 @@ func (p *ListVolumesParams) toURLValues() url.Values {
 		u.Set("storageid", v.(string))
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["type"]; found {

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -781,11 +781,10 @@ func (p *ListZonesParams) toURLValues() url.Values {
 		u.Set("showcapacities", vv)
 	}
 	if v, found := p.p["tags"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("tags[%d].key", i), k)
-			u.Set(fmt.Sprintf("tags[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("tags[%d].value", i), m[k])
 		}
 	}
 	return u
@@ -1107,11 +1106,10 @@ func (p *UpdateZoneParams) toURLValues() url.Values {
 		u.Set("allocationstate", v.(string))
 	}
 	if v, found := p.p["details"]; found {
-		i := 0
-		for k, vv := range v.(map[string]string) {
+		m := v.(map[string]string)
+		for i, k := range getSortedKeysFromMap(m) {
 			u.Set(fmt.Sprintf("details[%d].key", i), k)
-			u.Set(fmt.Sprintf("details[%d].value", i), vv)
-			i++
+			u.Set(fmt.Sprintf("details[%d].value", i), m[k])
 		}
 	}
 	if v, found := p.p["dhcpprovider"]; found {

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -428,6 +428,15 @@ func getRawValue(b json.RawMessage) (json.RawMessage, error) {
 	return nil, fmt.Errorf("Unable to extract the raw value from:\n\n%s\n\n", string(b))
 }
 
+// getSortedKeysFromMap returns the keys from m in increasing order.
+func getSortedKeysFromMap(m map[string]string) (keys []string) {
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return
+}
+
 // WithAsyncTimeout takes a custom timeout to be used by the CloudStackClient
 func WithAsyncTimeout(timeout int64) ClientOption {
 	return func(cs *CloudStackClient) {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -503,6 +503,15 @@ func (as *allServices) GeneralCode() ([]byte, error) {
 	pn("	return nil, fmt.Errorf(\"Unable to extract the raw value from:\\n\\n%%s\\n\\n\", string(b))")
 	pn("}")
 	pn("")
+	pn("// getSortedKeysFromMap returns the keys from m in increasing order.")
+	pn("func getSortedKeysFromMap(m map[string]string) (keys []string) {")
+	pn("	for k := range m {")
+	pn("		keys = append(keys, k)")
+	pn("	}")
+	pn("	sort.Strings(keys)")
+	pn("	return")
+	pn("}")
+	pn("")
 	pn("// WithAsyncTimeout takes a custom timeout to be used by the CloudStackClient")
 	pn("func WithAsyncTimeout(timeout int64) ClientOption {")
 	pn("	return func(cs *CloudStackClient) {")
@@ -830,15 +839,6 @@ func (s *service) GenerateCode() ([]byte, error) {
 		pn("	}")
 		pn("")
 		pn("	return json.Unmarshal(resp, result)")
-		pn("}")
-	}
-	if s.name == "ResourcetagsService" {
-		pn("func getSortedKeysFromMap(m map[string]string) (keys []string) {")
-		pn("	for k := range m {")
-		pn("		keys = append(keys, k)")
-		pn("	}")
-		pn("	sort.Strings(keys)")
-		pn("	return")
 		pn("}")
 	}
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -832,6 +832,15 @@ func (s *service) GenerateCode() ([]byte, error) {
 		pn("	return json.Unmarshal(resp, result)")
 		pn("}")
 	}
+	if s.name == "ResourcetagsService" {
+		pn("func getSortedKeysFromMap(m map[string]string) (keys []string) {")
+		pn("	for k := range m {")
+		pn("		keys = append(keys, k)")
+		pn("	}")
+		pn("	sort.Strings(keys)")
+		pn("	return")
+		pn("}")
+	}
 
 	for _, a := range s.apis {
 		s.generateParamType(a)
@@ -898,27 +907,26 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 		pn("vv := strings.Join(v.([]string), \",\")")
 		pn("u.Set(\"%s\", vv)", name)
 	case "map[string]string":
-		pn("i := 0")
-		pn("for k, vv := range v.(map[string]string) {")
+		pn("m := v.(map[string]string)")
+		pn("for i, k := range getSortedKeysFromMap(m) {")
 		switch name {
 		case "details":
 			if detailsRequireKeyValue[cmd] {
 				pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", name)
-				pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), vv)", name)
+				pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
 			} else {
-				pn("	u.Set(fmt.Sprintf(\"%s[%%d].%%s\", i, k), vv)", name)
+				pn("	u.Set(fmt.Sprintf(\"%s[%%d].%%s\", i, k), m[k])", name)
 			}
 		case "serviceproviderlist":
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].service\", i), k)", name)
-			pn("	u.Set(fmt.Sprintf(\"%s[%%d].provider\", i), vv)", name)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].provider\", i), m[k])", name)
 		case "usersecuritygrouplist":
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].account\", i), k)", name)
-			pn("	u.Set(fmt.Sprintf(\"%s[%%d].group\", i), vv)", name)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].group\", i), m[k])", name)
 		default:
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", name)
-			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), vv)", name)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
 		}
-		pn("	i++")
 		pn("}")
 	}
 	return


### PR DESCRIPTION
In order to make automated tests as consistent as possible, this PR makes sure that provided tags are sent to the CloudStack in a predictable order (sorted by tag key in lexicographic order) either on `createTags` or `deleteTags` commands.