### PR TITLE
Fix bug while list capabilties

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Another nice feature is the fact that for every API command you can create the n
 
 Last but not least there are a whole lot of helper function that will try to automatically find an UUID for you for a certain item (disk, template, virtualmachine, network...). This makes it much easier and faster to work with the API commands and in most cases you can just use then if you know the name instead of the UUID.
 
-## ToDO
+## ToDo
 
 I fully understand I need to document this all a little more/better and there should also be some tests added.
 

--- a/cloudstack/APIDiscoveryService.go
+++ b/cloudstack/APIDiscoveryService.go
@@ -41,7 +41,6 @@ func (p *ListApisParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new ListApisParams instance,

--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -50,7 +50,6 @@ func (p *AddAccountToProjectParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AddAccountToProjectParams) SetEmail(v string) {
@@ -58,7 +57,6 @@ func (p *AddAccountToProjectParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
-	return
 }
 
 func (p *AddAccountToProjectParams) SetProjectid(v string) {
@@ -66,7 +64,6 @@ func (p *AddAccountToProjectParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new AddAccountToProjectParams instance,
@@ -179,7 +176,6 @@ func (p *CreateAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetAccountdetails(v map[string]string) {
@@ -187,7 +183,6 @@ func (p *CreateAccountParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetAccountid(v string) {
@@ -195,7 +190,6 @@ func (p *CreateAccountParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetAccounttype(v int) {
@@ -203,7 +197,6 @@ func (p *CreateAccountParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetDomainid(v string) {
@@ -211,7 +204,6 @@ func (p *CreateAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetEmail(v string) {
@@ -219,7 +211,6 @@ func (p *CreateAccountParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetFirstname(v string) {
@@ -227,7 +218,6 @@ func (p *CreateAccountParams) SetFirstname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["firstname"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetLastname(v string) {
@@ -235,7 +225,6 @@ func (p *CreateAccountParams) SetLastname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lastname"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetNetworkdomain(v string) {
@@ -243,7 +232,6 @@ func (p *CreateAccountParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetPassword(v string) {
@@ -251,7 +239,6 @@ func (p *CreateAccountParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetRoleid(v string) {
@@ -259,7 +246,6 @@ func (p *CreateAccountParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetTimezone(v string) {
@@ -267,7 +253,6 @@ func (p *CreateAccountParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetUserid(v string) {
@@ -275,7 +260,6 @@ func (p *CreateAccountParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
-	return
 }
 
 func (p *CreateAccountParams) SetUsername(v string) {
@@ -283,7 +267,6 @@ func (p *CreateAccountParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new CreateAccountParams instance,
@@ -423,7 +406,6 @@ func (p *DeleteAccountParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAccountParams instance,
@@ -495,7 +477,6 @@ func (p *DeleteAccountFromProjectParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DeleteAccountFromProjectParams) SetProjectid(v string) {
@@ -503,7 +484,6 @@ func (p *DeleteAccountFromProjectParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAccountFromProjectParams instance,
@@ -583,7 +563,6 @@ func (p *DisableAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DisableAccountParams) SetDomainid(v string) {
@@ -591,7 +570,6 @@ func (p *DisableAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DisableAccountParams) SetId(v string) {
@@ -599,7 +577,6 @@ func (p *DisableAccountParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DisableAccountParams) SetLock(v bool) {
@@ -607,7 +584,6 @@ func (p *DisableAccountParams) SetLock(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lock"] = v
-	return
 }
 
 // You should always use this function to get a new DisableAccountParams instance,
@@ -765,7 +741,6 @@ func (p *EnableAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *EnableAccountParams) SetDomainid(v string) {
@@ -773,7 +748,6 @@ func (p *EnableAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *EnableAccountParams) SetId(v string) {
@@ -781,7 +755,6 @@ func (p *EnableAccountParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new EnableAccountParams instance,
@@ -915,7 +888,6 @@ func (p *GetSolidFireAccountIdParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *GetSolidFireAccountIdParams) SetStorageid(v string) {
@@ -923,7 +895,6 @@ func (p *GetSolidFireAccountIdParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 // You should always use this function to get a new GetSolidFireAccountIdParams instance,
@@ -1013,7 +984,6 @@ func (p *ListAccountsParams) SetAccounttype(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetDomainid(v string) {
@@ -1021,7 +991,6 @@ func (p *ListAccountsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetId(v string) {
@@ -1029,7 +998,6 @@ func (p *ListAccountsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetIscleanuprequired(v bool) {
@@ -1037,7 +1005,6 @@ func (p *ListAccountsParams) SetIscleanuprequired(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iscleanuprequired"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetIsrecursive(v bool) {
@@ -1045,7 +1012,6 @@ func (p *ListAccountsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetKeyword(v string) {
@@ -1053,7 +1019,6 @@ func (p *ListAccountsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetListall(v bool) {
@@ -1061,7 +1026,6 @@ func (p *ListAccountsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetName(v string) {
@@ -1069,7 +1033,6 @@ func (p *ListAccountsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetPage(v int) {
@@ -1077,7 +1040,6 @@ func (p *ListAccountsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetPagesize(v int) {
@@ -1085,7 +1047,6 @@ func (p *ListAccountsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAccountsParams) SetState(v string) {
@@ -1093,7 +1054,6 @@ func (p *ListAccountsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 // You should always use this function to get a new ListAccountsParams instance,
@@ -1329,7 +1289,6 @@ func (p *ListProjectAccountsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListProjectAccountsParams) SetKeyword(v string) {
@@ -1337,7 +1296,6 @@ func (p *ListProjectAccountsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListProjectAccountsParams) SetPage(v int) {
@@ -1345,7 +1303,6 @@ func (p *ListProjectAccountsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListProjectAccountsParams) SetPagesize(v int) {
@@ -1353,7 +1310,6 @@ func (p *ListProjectAccountsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListProjectAccountsParams) SetProjectid(v string) {
@@ -1361,7 +1317,6 @@ func (p *ListProjectAccountsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListProjectAccountsParams) SetRole(v string) {
@@ -1369,7 +1324,6 @@ func (p *ListProjectAccountsParams) SetRole(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["role"] = v
-	return
 }
 
 // You should always use this function to get a new ListProjectAccountsParams instance,
@@ -1523,7 +1477,6 @@ func (p *LockAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *LockAccountParams) SetDomainid(v string) {
@@ -1531,7 +1484,6 @@ func (p *LockAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 // You should always use this function to get a new LockAccountParams instance,
@@ -1670,7 +1622,6 @@ func (p *MarkDefaultZoneForAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *MarkDefaultZoneForAccountParams) SetDomainid(v string) {
@@ -1678,7 +1629,6 @@ func (p *MarkDefaultZoneForAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *MarkDefaultZoneForAccountParams) SetZoneid(v string) {
@@ -1686,7 +1636,6 @@ func (p *MarkDefaultZoneForAccountParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new MarkDefaultZoneForAccountParams instance,
@@ -1862,7 +1811,6 @@ func (p *UpdateAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpdateAccountParams) SetAccountdetails(v map[string]string) {
@@ -1870,7 +1818,6 @@ func (p *UpdateAccountParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
-	return
 }
 
 func (p *UpdateAccountParams) SetDomainid(v string) {
@@ -1878,7 +1825,6 @@ func (p *UpdateAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UpdateAccountParams) SetId(v string) {
@@ -1886,7 +1832,6 @@ func (p *UpdateAccountParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateAccountParams) SetNetworkdomain(v string) {
@@ -1894,7 +1839,6 @@ func (p *UpdateAccountParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *UpdateAccountParams) SetNewname(v string) {
@@ -1902,7 +1846,6 @@ func (p *UpdateAccountParams) SetNewname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["newname"] = v
-	return
 }
 
 func (p *UpdateAccountParams) SetRoleid(v string) {
@@ -1910,7 +1853,6 @@ func (p *UpdateAccountParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateAccountParams instance,

--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -71,7 +71,6 @@ func (p *AssociateIpAddressParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetDomainid(v string) {
@@ -79,7 +78,6 @@ func (p *AssociateIpAddressParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetFordisplay(v bool) {
@@ -87,7 +85,6 @@ func (p *AssociateIpAddressParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetIsportable(v bool) {
@@ -95,7 +92,6 @@ func (p *AssociateIpAddressParams) SetIsportable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isportable"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetNetworkid(v string) {
@@ -103,7 +99,6 @@ func (p *AssociateIpAddressParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetProjectid(v string) {
@@ -111,7 +106,6 @@ func (p *AssociateIpAddressParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetRegionid(v int) {
@@ -119,7 +113,6 @@ func (p *AssociateIpAddressParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetVpcid(v string) {
@@ -127,7 +120,6 @@ func (p *AssociateIpAddressParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *AssociateIpAddressParams) SetZoneid(v string) {
@@ -135,7 +127,6 @@ func (p *AssociateIpAddressParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AssociateIpAddressParams instance,
@@ -236,7 +227,6 @@ func (p *DisassociateIpAddressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DisassociateIpAddressParams instance,
@@ -385,7 +375,6 @@ func (p *ListPublicIpAddressesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetAllocatedonly(v bool) {
@@ -393,7 +382,6 @@ func (p *ListPublicIpAddressesParams) SetAllocatedonly(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocatedonly"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetAssociatednetworkid(v string) {
@@ -401,7 +389,6 @@ func (p *ListPublicIpAddressesParams) SetAssociatednetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["associatednetworkid"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetDomainid(v string) {
@@ -409,7 +396,6 @@ func (p *ListPublicIpAddressesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetFordisplay(v bool) {
@@ -417,7 +403,6 @@ func (p *ListPublicIpAddressesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetForloadbalancing(v bool) {
@@ -425,7 +410,6 @@ func (p *ListPublicIpAddressesParams) SetForloadbalancing(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forloadbalancing"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetForvirtualnetwork(v bool) {
@@ -433,7 +417,6 @@ func (p *ListPublicIpAddressesParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetId(v string) {
@@ -441,7 +424,6 @@ func (p *ListPublicIpAddressesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetIpaddress(v string) {
@@ -449,7 +431,6 @@ func (p *ListPublicIpAddressesParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetIsrecursive(v bool) {
@@ -457,7 +438,6 @@ func (p *ListPublicIpAddressesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetIssourcenat(v bool) {
@@ -465,7 +445,6 @@ func (p *ListPublicIpAddressesParams) SetIssourcenat(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["issourcenat"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetIsstaticnat(v bool) {
@@ -473,7 +452,6 @@ func (p *ListPublicIpAddressesParams) SetIsstaticnat(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isstaticnat"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetKeyword(v string) {
@@ -481,7 +459,6 @@ func (p *ListPublicIpAddressesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetListall(v bool) {
@@ -489,7 +466,6 @@ func (p *ListPublicIpAddressesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetPage(v int) {
@@ -497,7 +473,6 @@ func (p *ListPublicIpAddressesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetPagesize(v int) {
@@ -505,7 +480,6 @@ func (p *ListPublicIpAddressesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetPhysicalnetworkid(v string) {
@@ -513,7 +487,6 @@ func (p *ListPublicIpAddressesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetProjectid(v string) {
@@ -521,7 +494,6 @@ func (p *ListPublicIpAddressesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetState(v string) {
@@ -529,7 +501,6 @@ func (p *ListPublicIpAddressesParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetTags(v map[string]string) {
@@ -537,7 +508,6 @@ func (p *ListPublicIpAddressesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetVlanid(v string) {
@@ -545,7 +515,6 @@ func (p *ListPublicIpAddressesParams) SetVlanid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlanid"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetVpcid(v string) {
@@ -553,7 +522,6 @@ func (p *ListPublicIpAddressesParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *ListPublicIpAddressesParams) SetZoneid(v string) {
@@ -561,7 +529,6 @@ func (p *ListPublicIpAddressesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListPublicIpAddressesParams instance,
@@ -687,7 +654,6 @@ func (p *UpdateIpAddressParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateIpAddressParams) SetFordisplay(v bool) {
@@ -695,7 +661,6 @@ func (p *UpdateIpAddressParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateIpAddressParams) SetId(v string) {
@@ -703,7 +668,6 @@ func (p *UpdateIpAddressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateIpAddressParams instance,

--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -59,7 +59,6 @@ func (p *CreateAffinityGroupParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateAffinityGroupParams) SetDescription(v string) {
@@ -67,7 +66,6 @@ func (p *CreateAffinityGroupParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateAffinityGroupParams) SetDomainid(v string) {
@@ -75,7 +73,6 @@ func (p *CreateAffinityGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateAffinityGroupParams) SetName(v string) {
@@ -83,7 +80,6 @@ func (p *CreateAffinityGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateAffinityGroupParams) SetProjectid(v string) {
@@ -91,7 +87,6 @@ func (p *CreateAffinityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateAffinityGroupParams) SetType(v string) {
@@ -99,7 +94,6 @@ func (p *CreateAffinityGroupParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new CreateAffinityGroupParams instance,
@@ -194,7 +188,6 @@ func (p *DeleteAffinityGroupParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DeleteAffinityGroupParams) SetDomainid(v string) {
@@ -202,7 +195,6 @@ func (p *DeleteAffinityGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DeleteAffinityGroupParams) SetId(v string) {
@@ -210,7 +202,6 @@ func (p *DeleteAffinityGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DeleteAffinityGroupParams) SetName(v string) {
@@ -218,7 +209,6 @@ func (p *DeleteAffinityGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *DeleteAffinityGroupParams) SetProjectid(v string) {
@@ -226,7 +216,6 @@ func (p *DeleteAffinityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAffinityGroupParams instance,
@@ -302,7 +291,6 @@ func (p *ListAffinityGroupTypesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAffinityGroupTypesParams) SetPage(v int) {
@@ -310,7 +298,6 @@ func (p *ListAffinityGroupTypesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAffinityGroupTypesParams) SetPagesize(v int) {
@@ -318,7 +305,6 @@ func (p *ListAffinityGroupTypesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListAffinityGroupTypesParams instance,
@@ -412,7 +398,6 @@ func (p *ListAffinityGroupsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetDomainid(v string) {
@@ -420,7 +405,6 @@ func (p *ListAffinityGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetId(v string) {
@@ -428,7 +412,6 @@ func (p *ListAffinityGroupsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetIsrecursive(v bool) {
@@ -436,7 +419,6 @@ func (p *ListAffinityGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetKeyword(v string) {
@@ -444,7 +426,6 @@ func (p *ListAffinityGroupsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetListall(v bool) {
@@ -452,7 +433,6 @@ func (p *ListAffinityGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetName(v string) {
@@ -460,7 +440,6 @@ func (p *ListAffinityGroupsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetPage(v int) {
@@ -468,7 +447,6 @@ func (p *ListAffinityGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetPagesize(v int) {
@@ -476,7 +454,6 @@ func (p *ListAffinityGroupsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetProjectid(v string) {
@@ -484,7 +461,6 @@ func (p *ListAffinityGroupsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetType(v string) {
@@ -492,7 +468,6 @@ func (p *ListAffinityGroupsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *ListAffinityGroupsParams) SetVirtualmachineid(v string) {
@@ -500,7 +475,6 @@ func (p *ListAffinityGroupsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new ListAffinityGroupsParams instance,
@@ -665,7 +639,6 @@ func (p *UpdateVMAffinityGroupParams) SetAffinitygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupids"] = v
-	return
 }
 
 func (p *UpdateVMAffinityGroupParams) SetAffinitygroupnames(v []string) {
@@ -673,7 +646,6 @@ func (p *UpdateVMAffinityGroupParams) SetAffinitygroupnames(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupnames"] = v
-	return
 }
 
 func (p *UpdateVMAffinityGroupParams) SetId(v string) {
@@ -681,7 +653,6 @@ func (p *UpdateVMAffinityGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVMAffinityGroupParams instance,

--- a/cloudstack/AlertService.go
+++ b/cloudstack/AlertService.go
@@ -54,7 +54,6 @@ func (p *ArchiveAlertsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *ArchiveAlertsParams) SetIds(v []string) {
@@ -62,7 +61,6 @@ func (p *ArchiveAlertsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *ArchiveAlertsParams) SetStartdate(v string) {
@@ -70,7 +68,6 @@ func (p *ArchiveAlertsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 func (p *ArchiveAlertsParams) SetType(v string) {
@@ -78,7 +75,6 @@ func (p *ArchiveAlertsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new ArchiveAlertsParams instance,
@@ -168,7 +164,6 @@ func (p *DeleteAlertsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *DeleteAlertsParams) SetIds(v []string) {
@@ -176,7 +171,6 @@ func (p *DeleteAlertsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *DeleteAlertsParams) SetStartdate(v string) {
@@ -184,7 +178,6 @@ func (p *DeleteAlertsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 func (p *DeleteAlertsParams) SetType(v string) {
@@ -192,7 +185,6 @@ func (p *DeleteAlertsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAlertsParams instance,
@@ -285,7 +277,6 @@ func (p *GenerateAlertParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *GenerateAlertParams) SetName(v string) {
@@ -293,7 +284,6 @@ func (p *GenerateAlertParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *GenerateAlertParams) SetPodid(v string) {
@@ -301,7 +291,6 @@ func (p *GenerateAlertParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *GenerateAlertParams) SetType(v int) {
@@ -309,7 +298,6 @@ func (p *GenerateAlertParams) SetType(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *GenerateAlertParams) SetZoneid(v string) {
@@ -317,7 +305,6 @@ func (p *GenerateAlertParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new GenerateAlertParams instance,
@@ -405,7 +392,6 @@ func (p *ListAlertsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListAlertsParams) SetKeyword(v string) {
@@ -413,7 +399,6 @@ func (p *ListAlertsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAlertsParams) SetName(v string) {
@@ -421,7 +406,6 @@ func (p *ListAlertsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListAlertsParams) SetPage(v int) {
@@ -429,7 +413,6 @@ func (p *ListAlertsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAlertsParams) SetPagesize(v int) {
@@ -437,7 +420,6 @@ func (p *ListAlertsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAlertsParams) SetType(v string) {
@@ -445,7 +427,6 @@ func (p *ListAlertsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new ListAlertsParams instance,

--- a/cloudstack/AsyncjobService.go
+++ b/cloudstack/AsyncjobService.go
@@ -68,7 +68,6 @@ func (p *ListAsyncJobsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetDomainid(v string) {
@@ -76,7 +75,6 @@ func (p *ListAsyncJobsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetIsrecursive(v bool) {
@@ -84,7 +82,6 @@ func (p *ListAsyncJobsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetKeyword(v string) {
@@ -92,7 +89,6 @@ func (p *ListAsyncJobsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetListall(v bool) {
@@ -100,7 +96,6 @@ func (p *ListAsyncJobsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetPage(v int) {
@@ -108,7 +103,6 @@ func (p *ListAsyncJobsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetPagesize(v int) {
@@ -116,7 +110,6 @@ func (p *ListAsyncJobsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAsyncJobsParams) SetStartdate(v string) {
@@ -124,7 +117,6 @@ func (p *ListAsyncJobsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 // You should always use this function to get a new ListAsyncJobsParams instance,
@@ -191,7 +183,6 @@ func (p *QueryAsyncJobResultParams) SetJobID(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["jobid"] = v
-	return
 }
 
 // You should always use this function to get a new QueryAsyncJobResultParams instance,

--- a/cloudstack/AuthenticationService.go
+++ b/cloudstack/AuthenticationService.go
@@ -52,7 +52,6 @@ func (p *LoginParams) SetDomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domain"] = v
-	return
 }
 
 func (p *LoginParams) SetDomainId(v int64) {
@@ -60,7 +59,6 @@ func (p *LoginParams) SetDomainId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainId"] = v
-	return
 }
 
 func (p *LoginParams) SetPassword(v string) {
@@ -68,7 +66,6 @@ func (p *LoginParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *LoginParams) SetUsername(v string) {
@@ -76,7 +73,6 @@ func (p *LoginParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new LoginParams instance,

--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -56,7 +56,6 @@ func (p *CreateAutoScalePolicyParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
-	return
 }
 
 func (p *CreateAutoScalePolicyParams) SetConditionids(v []string) {
@@ -64,7 +63,6 @@ func (p *CreateAutoScalePolicyParams) SetConditionids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["conditionids"] = v
-	return
 }
 
 func (p *CreateAutoScalePolicyParams) SetDuration(v int) {
@@ -72,7 +70,6 @@ func (p *CreateAutoScalePolicyParams) SetDuration(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["duration"] = v
-	return
 }
 
 func (p *CreateAutoScalePolicyParams) SetQuiettime(v int) {
@@ -80,7 +77,6 @@ func (p *CreateAutoScalePolicyParams) SetQuiettime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["quiettime"] = v
-	return
 }
 
 // You should always use this function to get a new CreateAutoScalePolicyParams instance,
@@ -191,7 +187,6 @@ func (p *CreateAutoScaleVmGroupParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetInterval(v int) {
@@ -199,7 +194,6 @@ func (p *CreateAutoScaleVmGroupParams) SetInterval(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["interval"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetLbruleid(v string) {
@@ -207,7 +201,6 @@ func (p *CreateAutoScaleVmGroupParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetMaxmembers(v int) {
@@ -215,7 +208,6 @@ func (p *CreateAutoScaleVmGroupParams) SetMaxmembers(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxmembers"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetMinmembers(v int) {
@@ -223,7 +215,6 @@ func (p *CreateAutoScaleVmGroupParams) SetMinmembers(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["minmembers"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
@@ -231,7 +222,6 @@ func (p *CreateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scaledownpolicyids"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
@@ -239,7 +229,6 @@ func (p *CreateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scaleuppolicyids"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmGroupParams) SetVmprofileid(v string) {
@@ -247,7 +236,6 @@ func (p *CreateAutoScaleVmGroupParams) SetVmprofileid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmprofileid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateAutoScaleVmGroupParams instance,
@@ -366,7 +354,6 @@ func (p *CreateAutoScaleVmProfileParams) SetAutoscaleuserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["autoscaleuserid"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
@@ -374,7 +361,6 @@ func (p *CreateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterparam"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetDestroyvmgraceperiod(v int) {
@@ -382,7 +368,6 @@ func (p *CreateAutoScaleVmProfileParams) SetDestroyvmgraceperiod(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destroyvmgraceperiod"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetFordisplay(v bool) {
@@ -390,7 +375,6 @@ func (p *CreateAutoScaleVmProfileParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetOtherdeployparams(v string) {
@@ -398,7 +382,6 @@ func (p *CreateAutoScaleVmProfileParams) SetOtherdeployparams(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["otherdeployparams"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetServiceofferingid(v string) {
@@ -406,7 +389,6 @@ func (p *CreateAutoScaleVmProfileParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetTemplateid(v string) {
@@ -414,7 +396,6 @@ func (p *CreateAutoScaleVmProfileParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *CreateAutoScaleVmProfileParams) SetZoneid(v string) {
@@ -422,7 +403,6 @@ func (p *CreateAutoScaleVmProfileParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateAutoScaleVmProfileParams instance,
@@ -522,7 +502,6 @@ func (p *CreateConditionParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateConditionParams) SetCounterid(v string) {
@@ -530,7 +509,6 @@ func (p *CreateConditionParams) SetCounterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterid"] = v
-	return
 }
 
 func (p *CreateConditionParams) SetDomainid(v string) {
@@ -538,7 +516,6 @@ func (p *CreateConditionParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateConditionParams) SetRelationaloperator(v string) {
@@ -546,7 +523,6 @@ func (p *CreateConditionParams) SetRelationaloperator(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["relationaloperator"] = v
-	return
 }
 
 func (p *CreateConditionParams) SetThreshold(v int64) {
@@ -554,7 +530,6 @@ func (p *CreateConditionParams) SetThreshold(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["threshold"] = v
-	return
 }
 
 // You should always use this function to get a new CreateConditionParams instance,
@@ -644,7 +619,6 @@ func (p *CreateCounterParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateCounterParams) SetSource(v string) {
@@ -652,7 +626,6 @@ func (p *CreateCounterParams) SetSource(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["source"] = v
-	return
 }
 
 func (p *CreateCounterParams) SetValue(v string) {
@@ -660,7 +633,6 @@ func (p *CreateCounterParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
-	return
 }
 
 // You should always use this function to get a new CreateCounterParams instance,
@@ -739,7 +711,6 @@ func (p *DeleteAutoScalePolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAutoScalePolicyParams instance,
@@ -808,7 +779,6 @@ func (p *DeleteAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAutoScaleVmGroupParams instance,
@@ -877,7 +847,6 @@ func (p *DeleteAutoScaleVmProfileParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteAutoScaleVmProfileParams instance,
@@ -946,7 +915,6 @@ func (p *DeleteConditionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteConditionParams instance,
@@ -1015,7 +983,6 @@ func (p *DeleteCounterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteCounterParams instance,
@@ -1084,7 +1051,6 @@ func (p *DisableAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DisableAutoScaleVmGroupParams instance,
@@ -1171,7 +1137,6 @@ func (p *EnableAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new EnableAutoScaleVmGroupParams instance,
@@ -1292,7 +1257,6 @@ func (p *ListAutoScalePoliciesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetAction(v string) {
@@ -1300,7 +1264,6 @@ func (p *ListAutoScalePoliciesParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetConditionid(v string) {
@@ -1308,7 +1271,6 @@ func (p *ListAutoScalePoliciesParams) SetConditionid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["conditionid"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetDomainid(v string) {
@@ -1316,7 +1278,6 @@ func (p *ListAutoScalePoliciesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetId(v string) {
@@ -1324,7 +1285,6 @@ func (p *ListAutoScalePoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetIsrecursive(v bool) {
@@ -1332,7 +1292,6 @@ func (p *ListAutoScalePoliciesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetKeyword(v string) {
@@ -1340,7 +1299,6 @@ func (p *ListAutoScalePoliciesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetListall(v bool) {
@@ -1348,7 +1306,6 @@ func (p *ListAutoScalePoliciesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetPage(v int) {
@@ -1356,7 +1313,6 @@ func (p *ListAutoScalePoliciesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetPagesize(v int) {
@@ -1364,7 +1320,6 @@ func (p *ListAutoScalePoliciesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAutoScalePoliciesParams) SetVmgroupid(v string) {
@@ -1372,7 +1327,6 @@ func (p *ListAutoScalePoliciesParams) SetVmgroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmgroupid"] = v
-	return
 }
 
 // You should always use this function to get a new ListAutoScalePoliciesParams instance,
@@ -1515,7 +1469,6 @@ func (p *ListAutoScaleVmGroupsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetDomainid(v string) {
@@ -1523,7 +1476,6 @@ func (p *ListAutoScaleVmGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetFordisplay(v bool) {
@@ -1531,7 +1483,6 @@ func (p *ListAutoScaleVmGroupsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetId(v string) {
@@ -1539,7 +1490,6 @@ func (p *ListAutoScaleVmGroupsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetIsrecursive(v bool) {
@@ -1547,7 +1497,6 @@ func (p *ListAutoScaleVmGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetKeyword(v string) {
@@ -1555,7 +1504,6 @@ func (p *ListAutoScaleVmGroupsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetLbruleid(v string) {
@@ -1563,7 +1511,6 @@ func (p *ListAutoScaleVmGroupsParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetListall(v bool) {
@@ -1571,7 +1518,6 @@ func (p *ListAutoScaleVmGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetPage(v int) {
@@ -1579,7 +1525,6 @@ func (p *ListAutoScaleVmGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetPagesize(v int) {
@@ -1587,7 +1532,6 @@ func (p *ListAutoScaleVmGroupsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetPolicyid(v string) {
@@ -1595,7 +1539,6 @@ func (p *ListAutoScaleVmGroupsParams) SetPolicyid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["policyid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetProjectid(v string) {
@@ -1603,7 +1546,6 @@ func (p *ListAutoScaleVmGroupsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetVmprofileid(v string) {
@@ -1611,7 +1553,6 @@ func (p *ListAutoScaleVmGroupsParams) SetVmprofileid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmprofileid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmGroupsParams) SetZoneid(v string) {
@@ -1619,7 +1560,6 @@ func (p *ListAutoScaleVmGroupsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListAutoScaleVmGroupsParams instance,
@@ -1767,7 +1707,6 @@ func (p *ListAutoScaleVmProfilesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetDomainid(v string) {
@@ -1775,7 +1714,6 @@ func (p *ListAutoScaleVmProfilesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetFordisplay(v bool) {
@@ -1783,7 +1721,6 @@ func (p *ListAutoScaleVmProfilesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetId(v string) {
@@ -1791,7 +1728,6 @@ func (p *ListAutoScaleVmProfilesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetIsrecursive(v bool) {
@@ -1799,7 +1735,6 @@ func (p *ListAutoScaleVmProfilesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetKeyword(v string) {
@@ -1807,7 +1742,6 @@ func (p *ListAutoScaleVmProfilesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetListall(v bool) {
@@ -1815,7 +1749,6 @@ func (p *ListAutoScaleVmProfilesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetOtherdeployparams(v string) {
@@ -1823,7 +1756,6 @@ func (p *ListAutoScaleVmProfilesParams) SetOtherdeployparams(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["otherdeployparams"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetPage(v int) {
@@ -1831,7 +1763,6 @@ func (p *ListAutoScaleVmProfilesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetPagesize(v int) {
@@ -1839,7 +1770,6 @@ func (p *ListAutoScaleVmProfilesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetProjectid(v string) {
@@ -1847,7 +1777,6 @@ func (p *ListAutoScaleVmProfilesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetServiceofferingid(v string) {
@@ -1855,7 +1784,6 @@ func (p *ListAutoScaleVmProfilesParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetTemplateid(v string) {
@@ -1863,7 +1791,6 @@ func (p *ListAutoScaleVmProfilesParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *ListAutoScaleVmProfilesParams) SetZoneid(v string) {
@@ -1871,7 +1798,6 @@ func (p *ListAutoScaleVmProfilesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListAutoScaleVmProfilesParams instance,
@@ -2004,7 +1930,6 @@ func (p *ListConditionsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetCounterid(v string) {
@@ -2012,7 +1937,6 @@ func (p *ListConditionsParams) SetCounterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterid"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetDomainid(v string) {
@@ -2020,7 +1944,6 @@ func (p *ListConditionsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetId(v string) {
@@ -2028,7 +1951,6 @@ func (p *ListConditionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetIsrecursive(v bool) {
@@ -2036,7 +1958,6 @@ func (p *ListConditionsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetKeyword(v string) {
@@ -2044,7 +1965,6 @@ func (p *ListConditionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetListall(v bool) {
@@ -2052,7 +1972,6 @@ func (p *ListConditionsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetPage(v int) {
@@ -2060,7 +1979,6 @@ func (p *ListConditionsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetPagesize(v int) {
@@ -2068,7 +1986,6 @@ func (p *ListConditionsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListConditionsParams) SetPolicyid(v string) {
@@ -2076,7 +1993,6 @@ func (p *ListConditionsParams) SetPolicyid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["policyid"] = v
-	return
 }
 
 // You should always use this function to get a new ListConditionsParams instance,
@@ -2192,7 +2108,6 @@ func (p *ListCountersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListCountersParams) SetKeyword(v string) {
@@ -2200,7 +2115,6 @@ func (p *ListCountersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListCountersParams) SetName(v string) {
@@ -2208,7 +2122,6 @@ func (p *ListCountersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListCountersParams) SetPage(v int) {
@@ -2216,7 +2129,6 @@ func (p *ListCountersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListCountersParams) SetPagesize(v int) {
@@ -2224,7 +2136,6 @@ func (p *ListCountersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListCountersParams) SetSource(v string) {
@@ -2232,7 +2143,6 @@ func (p *ListCountersParams) SetSource(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["source"] = v
-	return
 }
 
 // You should always use this function to get a new ListCountersParams instance,
@@ -2388,7 +2298,6 @@ func (p *UpdateAutoScalePolicyParams) SetConditionids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["conditionids"] = v
-	return
 }
 
 func (p *UpdateAutoScalePolicyParams) SetDuration(v int) {
@@ -2396,7 +2305,6 @@ func (p *UpdateAutoScalePolicyParams) SetDuration(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["duration"] = v
-	return
 }
 
 func (p *UpdateAutoScalePolicyParams) SetId(v string) {
@@ -2404,7 +2312,6 @@ func (p *UpdateAutoScalePolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateAutoScalePolicyParams) SetQuiettime(v int) {
@@ -2412,7 +2319,6 @@ func (p *UpdateAutoScalePolicyParams) SetQuiettime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["quiettime"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateAutoScalePolicyParams instance,
@@ -2521,7 +2427,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetFordisplay(v bool) {
@@ -2529,7 +2434,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetId(v string) {
@@ -2537,7 +2441,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetInterval(v int) {
@@ -2545,7 +2448,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetInterval(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["interval"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetMaxmembers(v int) {
@@ -2553,7 +2455,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetMaxmembers(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxmembers"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetMinmembers(v int) {
@@ -2561,7 +2462,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetMinmembers(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["minmembers"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
@@ -2569,7 +2469,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scaledownpolicyids"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
@@ -2577,7 +2476,6 @@ func (p *UpdateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scaleuppolicyids"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateAutoScaleVmGroupParams instance,
@@ -2688,7 +2586,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetAutoscaleuserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["autoscaleuserid"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
@@ -2696,7 +2593,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterparam"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmProfileParams) SetCustomid(v string) {
@@ -2704,7 +2600,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmProfileParams) SetDestroyvmgraceperiod(v int) {
@@ -2712,7 +2607,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetDestroyvmgraceperiod(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destroyvmgraceperiod"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmProfileParams) SetFordisplay(v bool) {
@@ -2720,7 +2614,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmProfileParams) SetId(v string) {
@@ -2728,7 +2621,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateAutoScaleVmProfileParams) SetTemplateid(v string) {
@@ -2736,7 +2628,6 @@ func (p *UpdateAutoScaleVmProfileParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateAutoScaleVmProfileParams instance,

--- a/cloudstack/BaremetalService.go
+++ b/cloudstack/BaremetalService.go
@@ -54,7 +54,6 @@ func (p *AddBaremetalDhcpParams) SetDhcpservertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpservertype"] = v
-	return
 }
 
 func (p *AddBaremetalDhcpParams) SetPassword(v string) {
@@ -62,7 +61,6 @@ func (p *AddBaremetalDhcpParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
@@ -70,7 +68,6 @@ func (p *AddBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddBaremetalDhcpParams) SetUrl(v string) {
@@ -78,7 +75,6 @@ func (p *AddBaremetalDhcpParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddBaremetalDhcpParams) SetUsername(v string) {
@@ -86,7 +82,6 @@ func (p *AddBaremetalDhcpParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddBaremetalDhcpParams instance,
@@ -185,7 +180,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) SetPhysicalnetworkid(v string) {
@@ -193,7 +187,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) SetPodid(v string) {
@@ -201,7 +194,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) SetPxeservertype(v string) {
@@ -209,7 +201,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPxeservertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pxeservertype"] = v
-	return
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) SetTftpdir(v string) {
@@ -217,7 +208,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetTftpdir(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tftpdir"] = v
-	return
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) SetUrl(v string) {
@@ -225,7 +215,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) SetUsername(v string) {
@@ -233,7 +222,6 @@ func (p *AddBaremetalPxeKickStartServerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddBaremetalPxeKickStartServerParams instance,
@@ -345,7 +333,6 @@ func (p *AddBaremetalPxePingServerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPhysicalnetworkid(v string) {
@@ -353,7 +340,6 @@ func (p *AddBaremetalPxePingServerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPingcifspassword(v string) {
@@ -361,7 +347,6 @@ func (p *AddBaremetalPxePingServerParams) SetPingcifspassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingcifspassword"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPingcifsusername(v string) {
@@ -369,7 +354,6 @@ func (p *AddBaremetalPxePingServerParams) SetPingcifsusername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingcifsusername"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPingdir(v string) {
@@ -377,7 +361,6 @@ func (p *AddBaremetalPxePingServerParams) SetPingdir(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingdir"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPingstorageserverip(v string) {
@@ -385,7 +368,6 @@ func (p *AddBaremetalPxePingServerParams) SetPingstorageserverip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingstorageserverip"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPodid(v string) {
@@ -393,7 +375,6 @@ func (p *AddBaremetalPxePingServerParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetPxeservertype(v string) {
@@ -401,7 +382,6 @@ func (p *AddBaremetalPxePingServerParams) SetPxeservertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pxeservertype"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetTftpdir(v string) {
@@ -409,7 +389,6 @@ func (p *AddBaremetalPxePingServerParams) SetTftpdir(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tftpdir"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetUrl(v string) {
@@ -417,7 +396,6 @@ func (p *AddBaremetalPxePingServerParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddBaremetalPxePingServerParams) SetUsername(v string) {
@@ -425,7 +403,6 @@ func (p *AddBaremetalPxePingServerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddBaremetalPxePingServerParams instance,
@@ -511,7 +488,6 @@ func (p *AddBaremetalRctParams) SetBaremetalrcturl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["baremetalrcturl"] = v
-	return
 }
 
 // You should always use this function to get a new AddBaremetalRctParams instance,
@@ -585,7 +561,6 @@ func (p *DeleteBaremetalRctParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteBaremetalRctParams instance,
@@ -672,7 +647,6 @@ func (p *ListBaremetalDhcpParams) SetDhcpservertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpservertype"] = v
-	return
 }
 
 func (p *ListBaremetalDhcpParams) SetId(v int64) {
@@ -680,7 +654,6 @@ func (p *ListBaremetalDhcpParams) SetId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListBaremetalDhcpParams) SetKeyword(v string) {
@@ -688,7 +661,6 @@ func (p *ListBaremetalDhcpParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListBaremetalDhcpParams) SetPage(v int) {
@@ -696,7 +668,6 @@ func (p *ListBaremetalDhcpParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListBaremetalDhcpParams) SetPagesize(v int) {
@@ -704,7 +675,6 @@ func (p *ListBaremetalDhcpParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
@@ -712,7 +682,6 @@ func (p *ListBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListBaremetalDhcpParams instance,
@@ -789,7 +758,6 @@ func (p *ListBaremetalPxeServersParams) SetId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListBaremetalPxeServersParams) SetKeyword(v string) {
@@ -797,7 +765,6 @@ func (p *ListBaremetalPxeServersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListBaremetalPxeServersParams) SetPage(v int) {
@@ -805,7 +772,6 @@ func (p *ListBaremetalPxeServersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListBaremetalPxeServersParams) SetPagesize(v int) {
@@ -813,7 +779,6 @@ func (p *ListBaremetalPxeServersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListBaremetalPxeServersParams) SetPhysicalnetworkid(v string) {
@@ -821,7 +786,6 @@ func (p *ListBaremetalPxeServersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListBaremetalPxeServersParams instance,
@@ -890,7 +854,6 @@ func (p *ListBaremetalRctParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListBaremetalRctParams) SetPage(v int) {
@@ -898,7 +861,6 @@ func (p *ListBaremetalRctParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListBaremetalRctParams) SetPagesize(v int) {
@@ -906,7 +868,6 @@ func (p *ListBaremetalRctParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListBaremetalRctParams instance,
@@ -964,7 +925,6 @@ func (p *NotifyBaremetalProvisionDoneParams) SetMac(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mac"] = v
-	return
 }
 
 // You should always use this function to get a new NotifyBaremetalProvisionDoneParams instance,

--- a/cloudstack/BigSwitchBCFService.go
+++ b/cloudstack/BigSwitchBCFService.go
@@ -55,7 +55,6 @@ func (p *AddBigSwitchBcfDeviceParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *AddBigSwitchBcfDeviceParams) SetNat(v bool) {
@@ -63,7 +62,6 @@ func (p *AddBigSwitchBcfDeviceParams) SetNat(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nat"] = v
-	return
 }
 
 func (p *AddBigSwitchBcfDeviceParams) SetPassword(v string) {
@@ -71,7 +69,6 @@ func (p *AddBigSwitchBcfDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddBigSwitchBcfDeviceParams) SetPhysicalnetworkid(v string) {
@@ -79,7 +76,6 @@ func (p *AddBigSwitchBcfDeviceParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddBigSwitchBcfDeviceParams) SetUsername(v string) {
@@ -87,7 +83,6 @@ func (p *AddBigSwitchBcfDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddBigSwitchBcfDeviceParams instance,
@@ -171,7 +166,6 @@ func (p *DeleteBigSwitchBcfDeviceParams) SetBcfdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bcfdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteBigSwitchBcfDeviceParams instance,
@@ -254,7 +248,6 @@ func (p *ListBigSwitchBcfDevicesParams) SetBcfdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bcfdeviceid"] = v
-	return
 }
 
 func (p *ListBigSwitchBcfDevicesParams) SetKeyword(v string) {
@@ -262,7 +255,6 @@ func (p *ListBigSwitchBcfDevicesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListBigSwitchBcfDevicesParams) SetPage(v int) {
@@ -270,7 +262,6 @@ func (p *ListBigSwitchBcfDevicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListBigSwitchBcfDevicesParams) SetPagesize(v int) {
@@ -278,7 +269,6 @@ func (p *ListBigSwitchBcfDevicesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListBigSwitchBcfDevicesParams) SetPhysicalnetworkid(v string) {
@@ -286,7 +276,6 @@ func (p *ListBigSwitchBcfDevicesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListBigSwitchBcfDevicesParams instance,

--- a/cloudstack/BrocadeVCSService.go
+++ b/cloudstack/BrocadeVCSService.go
@@ -52,7 +52,6 @@ func (p *AddBrocadeVcsDeviceParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *AddBrocadeVcsDeviceParams) SetPassword(v string) {
@@ -60,7 +59,6 @@ func (p *AddBrocadeVcsDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddBrocadeVcsDeviceParams) SetPhysicalnetworkid(v string) {
@@ -68,7 +66,6 @@ func (p *AddBrocadeVcsDeviceParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddBrocadeVcsDeviceParams) SetUsername(v string) {
@@ -76,7 +73,6 @@ func (p *AddBrocadeVcsDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddBrocadeVcsDeviceParams instance,
@@ -156,7 +152,6 @@ func (p *DeleteBrocadeVcsDeviceParams) SetVcsdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vcsdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteBrocadeVcsDeviceParams instance,
@@ -236,7 +231,6 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDeviceNetworksParams) SetPage(v int) {
@@ -244,7 +238,6 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDeviceNetworksParams) SetPagesize(v int) {
@@ -252,7 +245,6 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDeviceNetworksParams) SetVcsdeviceid(v string) {
@@ -260,7 +252,6 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetVcsdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vcsdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new ListBrocadeVcsDeviceNetworksParams instance,
@@ -440,7 +431,6 @@ func (p *ListBrocadeVcsDevicesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDevicesParams) SetPage(v int) {
@@ -448,7 +438,6 @@ func (p *ListBrocadeVcsDevicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDevicesParams) SetPagesize(v int) {
@@ -456,7 +445,6 @@ func (p *ListBrocadeVcsDevicesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDevicesParams) SetPhysicalnetworkid(v string) {
@@ -464,7 +452,6 @@ func (p *ListBrocadeVcsDevicesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListBrocadeVcsDevicesParams) SetVcsdeviceid(v string) {
@@ -472,7 +459,6 @@ func (p *ListBrocadeVcsDevicesParams) SetVcsdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vcsdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new ListBrocadeVcsDevicesParams instance,

--- a/cloudstack/CertificateService.go
+++ b/cloudstack/CertificateService.go
@@ -55,7 +55,6 @@ func (p *UploadCustomCertificateParams) SetCertificate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certificate"] = v
-	return
 }
 
 func (p *UploadCustomCertificateParams) SetDomainsuffix(v string) {
@@ -63,7 +62,6 @@ func (p *UploadCustomCertificateParams) SetDomainsuffix(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainsuffix"] = v
-	return
 }
 
 func (p *UploadCustomCertificateParams) SetId(v int) {
@@ -71,7 +69,6 @@ func (p *UploadCustomCertificateParams) SetId(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UploadCustomCertificateParams) SetName(v string) {
@@ -79,7 +76,6 @@ func (p *UploadCustomCertificateParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UploadCustomCertificateParams) SetPrivatekey(v string) {
@@ -87,7 +83,6 @@ func (p *UploadCustomCertificateParams) SetPrivatekey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privatekey"] = v
-	return
 }
 
 // You should always use this function to get a new UploadCustomCertificateParams instance,

--- a/cloudstack/CloudIdentifierService.go
+++ b/cloudstack/CloudIdentifierService.go
@@ -41,7 +41,6 @@ func (p *GetCloudIdentifierParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
-	return
 }
 
 // You should always use this function to get a new GetCloudIdentifierParams instance,

--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -98,7 +98,6 @@ func (p *AddClusterParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *AddClusterParams) SetClustername(v string) {
@@ -106,7 +105,6 @@ func (p *AddClusterParams) SetClustername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustername"] = v
-	return
 }
 
 func (p *AddClusterParams) SetClustertype(v string) {
@@ -114,7 +112,6 @@ func (p *AddClusterParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
-	return
 }
 
 func (p *AddClusterParams) SetGuestvswitchname(v string) {
@@ -122,7 +119,6 @@ func (p *AddClusterParams) SetGuestvswitchname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestvswitchname"] = v
-	return
 }
 
 func (p *AddClusterParams) SetGuestvswitchtype(v string) {
@@ -130,7 +126,6 @@ func (p *AddClusterParams) SetGuestvswitchtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestvswitchtype"] = v
-	return
 }
 
 func (p *AddClusterParams) SetHypervisor(v string) {
@@ -138,7 +133,6 @@ func (p *AddClusterParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *AddClusterParams) SetOvm3cluster(v string) {
@@ -146,7 +140,6 @@ func (p *AddClusterParams) SetOvm3cluster(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3cluster"] = v
-	return
 }
 
 func (p *AddClusterParams) SetOvm3pool(v string) {
@@ -154,7 +147,6 @@ func (p *AddClusterParams) SetOvm3pool(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3pool"] = v
-	return
 }
 
 func (p *AddClusterParams) SetOvm3vip(v string) {
@@ -162,7 +154,6 @@ func (p *AddClusterParams) SetOvm3vip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3vip"] = v
-	return
 }
 
 func (p *AddClusterParams) SetPassword(v string) {
@@ -170,7 +161,6 @@ func (p *AddClusterParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddClusterParams) SetPodid(v string) {
@@ -178,7 +168,6 @@ func (p *AddClusterParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *AddClusterParams) SetPublicvswitchname(v string) {
@@ -186,7 +175,6 @@ func (p *AddClusterParams) SetPublicvswitchname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicvswitchname"] = v
-	return
 }
 
 func (p *AddClusterParams) SetPublicvswitchtype(v string) {
@@ -194,7 +182,6 @@ func (p *AddClusterParams) SetPublicvswitchtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicvswitchtype"] = v
-	return
 }
 
 func (p *AddClusterParams) SetUrl(v string) {
@@ -202,7 +189,6 @@ func (p *AddClusterParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddClusterParams) SetUsername(v string) {
@@ -210,7 +196,6 @@ func (p *AddClusterParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 func (p *AddClusterParams) SetVsmipaddress(v string) {
@@ -218,7 +203,6 @@ func (p *AddClusterParams) SetVsmipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vsmipaddress"] = v
-	return
 }
 
 func (p *AddClusterParams) SetVsmpassword(v string) {
@@ -226,7 +210,6 @@ func (p *AddClusterParams) SetVsmpassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vsmpassword"] = v
-	return
 }
 
 func (p *AddClusterParams) SetVsmusername(v string) {
@@ -234,7 +217,6 @@ func (p *AddClusterParams) SetVsmusername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vsmusername"] = v
-	return
 }
 
 func (p *AddClusterParams) SetZoneid(v string) {
@@ -242,7 +224,6 @@ func (p *AddClusterParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddClusterParams instance,
@@ -334,7 +315,6 @@ func (p *DedicateClusterParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DedicateClusterParams) SetClusterid(v string) {
@@ -342,7 +322,6 @@ func (p *DedicateClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *DedicateClusterParams) SetDomainid(v string) {
@@ -350,7 +329,6 @@ func (p *DedicateClusterParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 // You should always use this function to get a new DedicateClusterParams instance,
@@ -429,7 +407,6 @@ func (p *DeleteClusterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteClusterParams instance,
@@ -510,7 +487,6 @@ func (p *DisableOutOfBandManagementForClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 // You should always use this function to get a new DisableOutOfBandManagementForClusterParams instance,
@@ -593,7 +569,6 @@ func (p *EnableOutOfBandManagementForClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 // You should always use this function to get a new EnableOutOfBandManagementForClusterParams instance,
@@ -712,7 +687,6 @@ func (p *ListClustersParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *ListClustersParams) SetClustertype(v string) {
@@ -720,7 +694,6 @@ func (p *ListClustersParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
-	return
 }
 
 func (p *ListClustersParams) SetHypervisor(v string) {
@@ -728,7 +701,6 @@ func (p *ListClustersParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListClustersParams) SetId(v string) {
@@ -736,7 +708,6 @@ func (p *ListClustersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListClustersParams) SetKeyword(v string) {
@@ -744,7 +715,6 @@ func (p *ListClustersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListClustersParams) SetManagedstate(v string) {
@@ -752,7 +722,6 @@ func (p *ListClustersParams) SetManagedstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managedstate"] = v
-	return
 }
 
 func (p *ListClustersParams) SetName(v string) {
@@ -760,7 +729,6 @@ func (p *ListClustersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListClustersParams) SetPage(v int) {
@@ -768,7 +736,6 @@ func (p *ListClustersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListClustersParams) SetPagesize(v int) {
@@ -776,7 +743,6 @@ func (p *ListClustersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListClustersParams) SetPodid(v string) {
@@ -784,7 +750,6 @@ func (p *ListClustersParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListClustersParams) SetShowcapacities(v bool) {
@@ -792,7 +757,6 @@ func (p *ListClustersParams) SetShowcapacities(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showcapacities"] = v
-	return
 }
 
 func (p *ListClustersParams) SetZoneid(v string) {
@@ -800,7 +764,6 @@ func (p *ListClustersParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListClustersParams instance,
@@ -989,7 +952,6 @@ func (p *ListDedicatedClustersParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListDedicatedClustersParams) SetAffinitygroupid(v string) {
@@ -997,7 +959,6 @@ func (p *ListDedicatedClustersParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
-	return
 }
 
 func (p *ListDedicatedClustersParams) SetClusterid(v string) {
@@ -1005,7 +966,6 @@ func (p *ListDedicatedClustersParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListDedicatedClustersParams) SetDomainid(v string) {
@@ -1013,7 +973,6 @@ func (p *ListDedicatedClustersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListDedicatedClustersParams) SetKeyword(v string) {
@@ -1021,7 +980,6 @@ func (p *ListDedicatedClustersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDedicatedClustersParams) SetPage(v int) {
@@ -1029,7 +987,6 @@ func (p *ListDedicatedClustersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDedicatedClustersParams) SetPagesize(v int) {
@@ -1037,7 +994,6 @@ func (p *ListDedicatedClustersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListDedicatedClustersParams instance,
@@ -1099,7 +1055,6 @@ func (p *ReleaseDedicatedClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 // You should always use this function to get a new ReleaseDedicatedClusterParams instance,
@@ -1183,7 +1138,6 @@ func (p *UpdateClusterParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *UpdateClusterParams) SetClustername(v string) {
@@ -1191,7 +1145,6 @@ func (p *UpdateClusterParams) SetClustername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustername"] = v
-	return
 }
 
 func (p *UpdateClusterParams) SetClustertype(v string) {
@@ -1199,7 +1152,6 @@ func (p *UpdateClusterParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
-	return
 }
 
 func (p *UpdateClusterParams) SetHypervisor(v string) {
@@ -1207,7 +1159,6 @@ func (p *UpdateClusterParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *UpdateClusterParams) SetId(v string) {
@@ -1215,7 +1166,6 @@ func (p *UpdateClusterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateClusterParams) SetManagedstate(v string) {
@@ -1223,7 +1173,6 @@ func (p *UpdateClusterParams) SetManagedstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managedstate"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateClusterParams instance,

--- a/cloudstack/ConfigurationService.go
+++ b/cloudstack/ConfigurationService.go
@@ -133,7 +133,6 @@ func (p *ListConfigurationsParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetCategory(v string) {
@@ -141,7 +140,6 @@ func (p *ListConfigurationsParams) SetCategory(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["category"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetClusterid(v string) {
@@ -149,7 +147,6 @@ func (p *ListConfigurationsParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetDomainid(v string) {
@@ -157,7 +154,6 @@ func (p *ListConfigurationsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetImagestoreuuid(v string) {
@@ -165,7 +161,6 @@ func (p *ListConfigurationsParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetKeyword(v string) {
@@ -173,7 +168,6 @@ func (p *ListConfigurationsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetName(v string) {
@@ -181,7 +175,6 @@ func (p *ListConfigurationsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetPage(v int) {
@@ -189,7 +182,6 @@ func (p *ListConfigurationsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetPagesize(v int) {
@@ -197,7 +189,6 @@ func (p *ListConfigurationsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetStorageid(v string) {
@@ -205,7 +196,6 @@ func (p *ListConfigurationsParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *ListConfigurationsParams) SetZoneid(v string) {
@@ -213,7 +203,6 @@ func (p *ListConfigurationsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListConfigurationsParams instance,
@@ -283,7 +272,6 @@ func (p *ListDeploymentPlannersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDeploymentPlannersParams) SetPage(v int) {
@@ -291,7 +279,6 @@ func (p *ListDeploymentPlannersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDeploymentPlannersParams) SetPagesize(v int) {
@@ -299,7 +286,6 @@ func (p *ListDeploymentPlannersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListDeploymentPlannersParams instance,
@@ -377,7 +363,6 @@ func (p *UpdateConfigurationParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetClusterid(v string) {
@@ -385,7 +370,6 @@ func (p *UpdateConfigurationParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetDomainid(v string) {
@@ -393,7 +377,6 @@ func (p *UpdateConfigurationParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetImagestoreuuid(v string) {
@@ -401,7 +384,6 @@ func (p *UpdateConfigurationParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetName(v string) {
@@ -409,7 +391,6 @@ func (p *UpdateConfigurationParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetStorageid(v string) {
@@ -417,7 +398,6 @@ func (p *UpdateConfigurationParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetValue(v string) {
@@ -425,7 +405,6 @@ func (p *UpdateConfigurationParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
-	return
 }
 
 func (p *UpdateConfigurationParams) SetZoneid(v string) {
@@ -433,7 +412,6 @@ func (p *UpdateConfigurationParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateConfigurationParams instance,

--- a/cloudstack/ConfigurationService.go
+++ b/cloudstack/ConfigurationService.go
@@ -58,8 +58,7 @@ func (s *ConfigurationService) ListCapabilities(p *ListCapabilitiesParams) (*Lis
 }
 
 type ListCapabilitiesResponse struct {
-	Count        int           `json:"count"`
-	Capabilities []*Capability `json:"capability"`
+	Capabilities *Capability `json:"capability"`
 }
 
 type Capability struct {

--- a/cloudstack/CustomService.go
+++ b/cloudstack/CustomService.go
@@ -64,7 +64,6 @@ func (p *CustomServiceParams) SetParam(param string, v interface{}) {
 		p.p = make(map[string]interface{})
 	}
 	p.p[param] = v
-	return
 }
 
 func (s *CustomService) CustomRequest(api string, p *CustomServiceParams, result interface{}) error {

--- a/cloudstack/DiskOfferingService.go
+++ b/cloudstack/DiskOfferingService.go
@@ -135,7 +135,6 @@ func (p *CreateDiskOfferingParams) SetBytesreadrate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadrate"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetBytesreadratemax(v int64) {
@@ -143,7 +142,6 @@ func (p *CreateDiskOfferingParams) SetBytesreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemax"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetBytesreadratemaxlength(v int64) {
@@ -151,7 +149,6 @@ func (p *CreateDiskOfferingParams) SetBytesreadratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemaxlength"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetByteswriterate(v int64) {
@@ -159,7 +156,6 @@ func (p *CreateDiskOfferingParams) SetByteswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriterate"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetByteswriteratemax(v int64) {
@@ -167,7 +163,6 @@ func (p *CreateDiskOfferingParams) SetByteswriteratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemax"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetByteswriteratemaxlength(v int64) {
@@ -175,7 +170,6 @@ func (p *CreateDiskOfferingParams) SetByteswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemaxlength"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetCustomized(v bool) {
@@ -183,7 +177,6 @@ func (p *CreateDiskOfferingParams) SetCustomized(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customized"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetCustomizediops(v bool) {
@@ -191,7 +184,6 @@ func (p *CreateDiskOfferingParams) SetCustomizediops(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customizediops"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetDisksize(v int64) {
@@ -199,7 +191,6 @@ func (p *CreateDiskOfferingParams) SetDisksize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["disksize"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetDisplayoffering(v bool) {
@@ -207,7 +198,6 @@ func (p *CreateDiskOfferingParams) SetDisplayoffering(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayoffering"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetDisplaytext(v string) {
@@ -215,7 +205,6 @@ func (p *CreateDiskOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetDomainid(v string) {
@@ -223,7 +212,6 @@ func (p *CreateDiskOfferingParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetHypervisorsnapshotreserve(v int) {
@@ -231,7 +219,6 @@ func (p *CreateDiskOfferingParams) SetHypervisorsnapshotreserve(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisorsnapshotreserve"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetIopsreadrate(v int64) {
@@ -239,7 +226,6 @@ func (p *CreateDiskOfferingParams) SetIopsreadrate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadrate"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetIopsreadratemax(v int64) {
@@ -247,7 +233,6 @@ func (p *CreateDiskOfferingParams) SetIopsreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemax"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetIopsreadratemaxlength(v int64) {
@@ -255,7 +240,6 @@ func (p *CreateDiskOfferingParams) SetIopsreadratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemaxlength"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetIopswriterate(v int64) {
@@ -263,7 +247,6 @@ func (p *CreateDiskOfferingParams) SetIopswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriterate"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetIopswriteratemax(v int64) {
@@ -271,7 +254,6 @@ func (p *CreateDiskOfferingParams) SetIopswriteratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemax"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetIopswriteratemaxlength(v int64) {
@@ -279,7 +261,6 @@ func (p *CreateDiskOfferingParams) SetIopswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemaxlength"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetMaxiops(v int64) {
@@ -287,7 +268,6 @@ func (p *CreateDiskOfferingParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetMiniops(v int64) {
@@ -295,7 +275,6 @@ func (p *CreateDiskOfferingParams) SetMiniops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["miniops"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetName(v string) {
@@ -303,7 +282,6 @@ func (p *CreateDiskOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetProvisioningtype(v string) {
@@ -311,7 +289,6 @@ func (p *CreateDiskOfferingParams) SetProvisioningtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provisioningtype"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetStoragetype(v string) {
@@ -319,7 +296,6 @@ func (p *CreateDiskOfferingParams) SetStoragetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storagetype"] = v
-	return
 }
 
 func (p *CreateDiskOfferingParams) SetTags(v string) {
@@ -327,7 +303,6 @@ func (p *CreateDiskOfferingParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new CreateDiskOfferingParams instance,
@@ -409,7 +384,6 @@ func (p *DeleteDiskOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteDiskOfferingParams instance,
@@ -515,7 +489,6 @@ func (p *ListDiskOfferingsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetId(v string) {
@@ -523,7 +496,6 @@ func (p *ListDiskOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetIsrecursive(v bool) {
@@ -531,7 +503,6 @@ func (p *ListDiskOfferingsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetKeyword(v string) {
@@ -539,7 +510,6 @@ func (p *ListDiskOfferingsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetListall(v bool) {
@@ -547,7 +517,6 @@ func (p *ListDiskOfferingsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetName(v string) {
@@ -555,7 +524,6 @@ func (p *ListDiskOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetPage(v int) {
@@ -563,7 +531,6 @@ func (p *ListDiskOfferingsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDiskOfferingsParams) SetPagesize(v int) {
@@ -571,7 +538,6 @@ func (p *ListDiskOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListDiskOfferingsParams instance,
@@ -753,7 +719,6 @@ func (p *UpdateDiskOfferingParams) SetDisplayoffering(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayoffering"] = v
-	return
 }
 
 func (p *UpdateDiskOfferingParams) SetDisplaytext(v string) {
@@ -761,7 +726,6 @@ func (p *UpdateDiskOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateDiskOfferingParams) SetId(v string) {
@@ -769,7 +733,6 @@ func (p *UpdateDiskOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateDiskOfferingParams) SetName(v string) {
@@ -777,7 +740,6 @@ func (p *UpdateDiskOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateDiskOfferingParams) SetSortkey(v int) {
@@ -785,7 +747,6 @@ func (p *UpdateDiskOfferingParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateDiskOfferingParams instance,

--- a/cloudstack/DomainService.go
+++ b/cloudstack/DomainService.go
@@ -53,7 +53,6 @@ func (p *CreateDomainParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateDomainParams) SetName(v string) {
@@ -61,7 +60,6 @@ func (p *CreateDomainParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateDomainParams) SetNetworkdomain(v string) {
@@ -69,7 +67,6 @@ func (p *CreateDomainParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *CreateDomainParams) SetParentdomainid(v string) {
@@ -77,7 +74,6 @@ func (p *CreateDomainParams) SetParentdomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["parentdomainid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateDomainParams instance,
@@ -178,7 +174,6 @@ func (p *DeleteDomainParams) SetCleanup(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanup"] = v
-	return
 }
 
 func (p *DeleteDomainParams) SetId(v string) {
@@ -186,7 +181,6 @@ func (p *DeleteDomainParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteDomainParams instance,
@@ -277,7 +271,6 @@ func (p *ListDomainChildrenParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListDomainChildrenParams) SetIsrecursive(v bool) {
@@ -285,7 +278,6 @@ func (p *ListDomainChildrenParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListDomainChildrenParams) SetKeyword(v string) {
@@ -293,7 +285,6 @@ func (p *ListDomainChildrenParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDomainChildrenParams) SetListall(v bool) {
@@ -301,7 +292,6 @@ func (p *ListDomainChildrenParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListDomainChildrenParams) SetName(v string) {
@@ -309,7 +299,6 @@ func (p *ListDomainChildrenParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListDomainChildrenParams) SetPage(v int) {
@@ -317,7 +306,6 @@ func (p *ListDomainChildrenParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDomainChildrenParams) SetPagesize(v int) {
@@ -325,7 +313,6 @@ func (p *ListDomainChildrenParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListDomainChildrenParams instance,
@@ -535,7 +522,6 @@ func (p *ListDomainsParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetId(v string) {
@@ -543,7 +529,6 @@ func (p *ListDomainsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetKeyword(v string) {
@@ -551,7 +536,6 @@ func (p *ListDomainsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetLevel(v int) {
@@ -559,7 +543,6 @@ func (p *ListDomainsParams) SetLevel(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["level"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetListall(v bool) {
@@ -567,7 +550,6 @@ func (p *ListDomainsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetName(v string) {
@@ -575,7 +557,6 @@ func (p *ListDomainsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetPage(v int) {
@@ -583,7 +564,6 @@ func (p *ListDomainsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDomainsParams) SetPagesize(v int) {
@@ -591,7 +571,6 @@ func (p *ListDomainsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListDomainsParams instance,
@@ -781,7 +760,6 @@ func (p *UpdateDomainParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateDomainParams) SetName(v string) {
@@ -789,7 +767,6 @@ func (p *UpdateDomainParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateDomainParams) SetNetworkdomain(v string) {
@@ -797,7 +774,6 @@ func (p *UpdateDomainParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateDomainParams instance,

--- a/cloudstack/EventService.go
+++ b/cloudstack/EventService.go
@@ -54,7 +54,6 @@ func (p *ArchiveEventsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *ArchiveEventsParams) SetIds(v []string) {
@@ -62,7 +61,6 @@ func (p *ArchiveEventsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *ArchiveEventsParams) SetStartdate(v string) {
@@ -70,7 +68,6 @@ func (p *ArchiveEventsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 func (p *ArchiveEventsParams) SetType(v string) {
@@ -78,7 +75,6 @@ func (p *ArchiveEventsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new ArchiveEventsParams instance,
@@ -168,7 +164,6 @@ func (p *DeleteEventsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *DeleteEventsParams) SetIds(v []string) {
@@ -176,7 +171,6 @@ func (p *DeleteEventsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *DeleteEventsParams) SetStartdate(v string) {
@@ -184,7 +178,6 @@ func (p *DeleteEventsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 func (p *DeleteEventsParams) SetType(v string) {
@@ -192,7 +185,6 @@ func (p *DeleteEventsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteEventsParams instance,
@@ -369,7 +361,6 @@ func (p *ListEventsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListEventsParams) SetDomainid(v string) {
@@ -377,7 +368,6 @@ func (p *ListEventsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListEventsParams) SetDuration(v int) {
@@ -385,7 +375,6 @@ func (p *ListEventsParams) SetDuration(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["duration"] = v
-	return
 }
 
 func (p *ListEventsParams) SetEnddate(v string) {
@@ -393,7 +382,6 @@ func (p *ListEventsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *ListEventsParams) SetEntrytime(v int) {
@@ -401,7 +389,6 @@ func (p *ListEventsParams) SetEntrytime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["entrytime"] = v
-	return
 }
 
 func (p *ListEventsParams) SetId(v string) {
@@ -409,7 +396,6 @@ func (p *ListEventsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListEventsParams) SetIsrecursive(v bool) {
@@ -417,7 +403,6 @@ func (p *ListEventsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListEventsParams) SetKeyword(v string) {
@@ -425,7 +410,6 @@ func (p *ListEventsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListEventsParams) SetLevel(v string) {
@@ -433,7 +417,6 @@ func (p *ListEventsParams) SetLevel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["level"] = v
-	return
 }
 
 func (p *ListEventsParams) SetListall(v bool) {
@@ -441,7 +424,6 @@ func (p *ListEventsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListEventsParams) SetPage(v int) {
@@ -449,7 +431,6 @@ func (p *ListEventsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListEventsParams) SetPagesize(v int) {
@@ -457,7 +438,6 @@ func (p *ListEventsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListEventsParams) SetProjectid(v string) {
@@ -465,7 +445,6 @@ func (p *ListEventsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListEventsParams) SetStartdate(v string) {
@@ -473,7 +452,6 @@ func (p *ListEventsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 func (p *ListEventsParams) SetStartid(v string) {
@@ -481,7 +459,6 @@ func (p *ListEventsParams) SetStartid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startid"] = v
-	return
 }
 
 func (p *ListEventsParams) SetType(v string) {
@@ -489,7 +466,6 @@ func (p *ListEventsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new ListEventsParams instance,

--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -106,7 +106,6 @@ func (p *AddPaloAltoFirewallParams) SetNetworkdevicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdevicetype"] = v
-	return
 }
 
 func (p *AddPaloAltoFirewallParams) SetPassword(v string) {
@@ -114,7 +113,6 @@ func (p *AddPaloAltoFirewallParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddPaloAltoFirewallParams) SetPhysicalnetworkid(v string) {
@@ -122,7 +120,6 @@ func (p *AddPaloAltoFirewallParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddPaloAltoFirewallParams) SetUrl(v string) {
@@ -130,7 +127,6 @@ func (p *AddPaloAltoFirewallParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddPaloAltoFirewallParams) SetUsername(v string) {
@@ -138,7 +134,6 @@ func (p *AddPaloAltoFirewallParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddPaloAltoFirewallParams instance,
@@ -239,7 +234,6 @@ func (p *ConfigurePaloAltoFirewallParams) SetFwdevicecapacity(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fwdevicecapacity"] = v
-	return
 }
 
 func (p *ConfigurePaloAltoFirewallParams) SetFwdeviceid(v string) {
@@ -247,7 +241,6 @@ func (p *ConfigurePaloAltoFirewallParams) SetFwdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fwdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new ConfigurePaloAltoFirewallParams instance,
@@ -374,7 +367,6 @@ func (p *CreateEgressFirewallRuleParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetDestcidrlist(v []string) {
@@ -382,7 +374,6 @@ func (p *CreateEgressFirewallRuleParams) SetDestcidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destcidrlist"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetEndport(v int) {
@@ -390,7 +381,6 @@ func (p *CreateEgressFirewallRuleParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetFordisplay(v bool) {
@@ -398,7 +388,6 @@ func (p *CreateEgressFirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetIcmpcode(v int) {
@@ -406,7 +395,6 @@ func (p *CreateEgressFirewallRuleParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetIcmptype(v int) {
@@ -414,7 +402,6 @@ func (p *CreateEgressFirewallRuleParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetNetworkid(v string) {
@@ -422,7 +409,6 @@ func (p *CreateEgressFirewallRuleParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetProtocol(v string) {
@@ -430,7 +416,6 @@ func (p *CreateEgressFirewallRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetStartport(v int) {
@@ -438,7 +423,6 @@ func (p *CreateEgressFirewallRuleParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 func (p *CreateEgressFirewallRuleParams) SetType(v string) {
@@ -446,7 +430,6 @@ func (p *CreateEgressFirewallRuleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new CreateEgressFirewallRuleParams instance,
@@ -568,7 +551,6 @@ func (p *CreateFirewallRuleParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetEndport(v int) {
@@ -576,7 +558,6 @@ func (p *CreateFirewallRuleParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetFordisplay(v bool) {
@@ -584,7 +565,6 @@ func (p *CreateFirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetIcmpcode(v int) {
@@ -592,7 +572,6 @@ func (p *CreateFirewallRuleParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetIcmptype(v int) {
@@ -600,7 +579,6 @@ func (p *CreateFirewallRuleParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetIpaddressid(v string) {
@@ -608,7 +586,6 @@ func (p *CreateFirewallRuleParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetProtocol(v string) {
@@ -616,7 +593,6 @@ func (p *CreateFirewallRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetStartport(v int) {
@@ -624,7 +600,6 @@ func (p *CreateFirewallRuleParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 func (p *CreateFirewallRuleParams) SetType(v string) {
@@ -632,7 +607,6 @@ func (p *CreateFirewallRuleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new CreateFirewallRuleParams instance,
@@ -764,7 +738,6 @@ func (p *CreatePortForwardingRuleParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetFordisplay(v bool) {
@@ -772,7 +745,6 @@ func (p *CreatePortForwardingRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetIpaddressid(v string) {
@@ -780,7 +752,6 @@ func (p *CreatePortForwardingRuleParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetNetworkid(v string) {
@@ -788,7 +759,6 @@ func (p *CreatePortForwardingRuleParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetOpenfirewall(v bool) {
@@ -796,7 +766,6 @@ func (p *CreatePortForwardingRuleParams) SetOpenfirewall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["openfirewall"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetPrivateendport(v int) {
@@ -804,7 +773,6 @@ func (p *CreatePortForwardingRuleParams) SetPrivateendport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateendport"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetPrivateport(v int) {
@@ -812,7 +780,6 @@ func (p *CreatePortForwardingRuleParams) SetPrivateport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateport"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetProtocol(v string) {
@@ -820,7 +787,6 @@ func (p *CreatePortForwardingRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetPublicendport(v int) {
@@ -828,7 +794,6 @@ func (p *CreatePortForwardingRuleParams) SetPublicendport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicendport"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetPublicport(v int) {
@@ -836,7 +801,6 @@ func (p *CreatePortForwardingRuleParams) SetPublicport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicport"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetVirtualmachineid(v string) {
@@ -844,7 +808,6 @@ func (p *CreatePortForwardingRuleParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *CreatePortForwardingRuleParams) SetVmguestip(v string) {
@@ -852,7 +815,6 @@ func (p *CreatePortForwardingRuleParams) SetVmguestip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmguestip"] = v
-	return
 }
 
 // You should always use this function to get a new CreatePortForwardingRuleParams instance,
@@ -950,7 +912,6 @@ func (p *DeleteEgressFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteEgressFirewallRuleParams instance,
@@ -1024,7 +985,6 @@ func (p *DeleteFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteFirewallRuleParams instance,
@@ -1098,7 +1058,6 @@ func (p *DeletePaloAltoFirewallParams) SetFwdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fwdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new DeletePaloAltoFirewallParams instance,
@@ -1172,7 +1131,6 @@ func (p *DeletePortForwardingRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeletePortForwardingRuleParams instance,
@@ -1291,7 +1249,6 @@ func (p *ListEgressFirewallRulesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetDomainid(v string) {
@@ -1299,7 +1256,6 @@ func (p *ListEgressFirewallRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetFordisplay(v bool) {
@@ -1307,7 +1263,6 @@ func (p *ListEgressFirewallRulesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetId(v string) {
@@ -1315,7 +1270,6 @@ func (p *ListEgressFirewallRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetIpaddressid(v string) {
@@ -1323,7 +1277,6 @@ func (p *ListEgressFirewallRulesParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetIsrecursive(v bool) {
@@ -1331,7 +1284,6 @@ func (p *ListEgressFirewallRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetKeyword(v string) {
@@ -1339,7 +1291,6 @@ func (p *ListEgressFirewallRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetListall(v bool) {
@@ -1347,7 +1298,6 @@ func (p *ListEgressFirewallRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetNetworkid(v string) {
@@ -1355,7 +1305,6 @@ func (p *ListEgressFirewallRulesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetPage(v int) {
@@ -1363,7 +1312,6 @@ func (p *ListEgressFirewallRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetPagesize(v int) {
@@ -1371,7 +1319,6 @@ func (p *ListEgressFirewallRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetProjectid(v string) {
@@ -1379,7 +1326,6 @@ func (p *ListEgressFirewallRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListEgressFirewallRulesParams) SetTags(v map[string]string) {
@@ -1387,7 +1333,6 @@ func (p *ListEgressFirewallRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListEgressFirewallRulesParams instance,
@@ -1540,7 +1485,6 @@ func (p *ListFirewallRulesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetDomainid(v string) {
@@ -1548,7 +1492,6 @@ func (p *ListFirewallRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetFordisplay(v bool) {
@@ -1556,7 +1499,6 @@ func (p *ListFirewallRulesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetId(v string) {
@@ -1564,7 +1506,6 @@ func (p *ListFirewallRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetIpaddressid(v string) {
@@ -1572,7 +1513,6 @@ func (p *ListFirewallRulesParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetIsrecursive(v bool) {
@@ -1580,7 +1520,6 @@ func (p *ListFirewallRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetKeyword(v string) {
@@ -1588,7 +1527,6 @@ func (p *ListFirewallRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetListall(v bool) {
@@ -1596,7 +1534,6 @@ func (p *ListFirewallRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetNetworkid(v string) {
@@ -1604,7 +1541,6 @@ func (p *ListFirewallRulesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetPage(v int) {
@@ -1612,7 +1548,6 @@ func (p *ListFirewallRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetPagesize(v int) {
@@ -1620,7 +1555,6 @@ func (p *ListFirewallRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetProjectid(v string) {
@@ -1628,7 +1562,6 @@ func (p *ListFirewallRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListFirewallRulesParams) SetTags(v map[string]string) {
@@ -1636,7 +1569,6 @@ func (p *ListFirewallRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListFirewallRulesParams instance,
@@ -1758,7 +1690,6 @@ func (p *ListPaloAltoFirewallsParams) SetFwdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fwdeviceid"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallsParams) SetKeyword(v string) {
@@ -1766,7 +1697,6 @@ func (p *ListPaloAltoFirewallsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallsParams) SetPage(v int) {
@@ -1774,7 +1704,6 @@ func (p *ListPaloAltoFirewallsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallsParams) SetPagesize(v int) {
@@ -1782,7 +1711,6 @@ func (p *ListPaloAltoFirewallsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallsParams) SetPhysicalnetworkid(v string) {
@@ -1790,7 +1718,6 @@ func (p *ListPaloAltoFirewallsParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListPaloAltoFirewallsParams instance,
@@ -1912,7 +1839,6 @@ func (p *ListPortForwardingRulesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetDomainid(v string) {
@@ -1920,7 +1846,6 @@ func (p *ListPortForwardingRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetFordisplay(v bool) {
@@ -1928,7 +1853,6 @@ func (p *ListPortForwardingRulesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetId(v string) {
@@ -1936,7 +1860,6 @@ func (p *ListPortForwardingRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetIpaddressid(v string) {
@@ -1944,7 +1867,6 @@ func (p *ListPortForwardingRulesParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetIsrecursive(v bool) {
@@ -1952,7 +1874,6 @@ func (p *ListPortForwardingRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetKeyword(v string) {
@@ -1960,7 +1881,6 @@ func (p *ListPortForwardingRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetListall(v bool) {
@@ -1968,7 +1888,6 @@ func (p *ListPortForwardingRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetNetworkid(v string) {
@@ -1976,7 +1895,6 @@ func (p *ListPortForwardingRulesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetPage(v int) {
@@ -1984,7 +1902,6 @@ func (p *ListPortForwardingRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetPagesize(v int) {
@@ -1992,7 +1909,6 @@ func (p *ListPortForwardingRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetProjectid(v string) {
@@ -2000,7 +1916,6 @@ func (p *ListPortForwardingRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListPortForwardingRulesParams) SetTags(v map[string]string) {
@@ -2008,7 +1923,6 @@ func (p *ListPortForwardingRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListPortForwardingRulesParams instance,
@@ -2126,7 +2040,6 @@ func (p *UpdateEgressFirewallRuleParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateEgressFirewallRuleParams) SetFordisplay(v bool) {
@@ -2134,7 +2047,6 @@ func (p *UpdateEgressFirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateEgressFirewallRuleParams) SetId(v string) {
@@ -2142,7 +2054,6 @@ func (p *UpdateEgressFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateEgressFirewallRuleParams instance,
@@ -2240,7 +2151,6 @@ func (p *UpdateFirewallRuleParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateFirewallRuleParams) SetFordisplay(v bool) {
@@ -2248,7 +2158,6 @@ func (p *UpdateFirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateFirewallRuleParams) SetId(v string) {
@@ -2256,7 +2165,6 @@ func (p *UpdateFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateFirewallRuleParams instance,
@@ -2368,7 +2276,6 @@ func (p *UpdatePortForwardingRuleParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdatePortForwardingRuleParams) SetFordisplay(v bool) {
@@ -2376,7 +2283,6 @@ func (p *UpdatePortForwardingRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdatePortForwardingRuleParams) SetId(v string) {
@@ -2384,7 +2290,6 @@ func (p *UpdatePortForwardingRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdatePortForwardingRuleParams) SetPrivateendport(v int) {
@@ -2392,7 +2297,6 @@ func (p *UpdatePortForwardingRuleParams) SetPrivateendport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateendport"] = v
-	return
 }
 
 func (p *UpdatePortForwardingRuleParams) SetPrivateport(v int) {
@@ -2400,7 +2304,6 @@ func (p *UpdatePortForwardingRuleParams) SetPrivateport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateport"] = v
-	return
 }
 
 func (p *UpdatePortForwardingRuleParams) SetVirtualmachineid(v string) {
@@ -2408,7 +2311,6 @@ func (p *UpdatePortForwardingRuleParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *UpdatePortForwardingRuleParams) SetVmguestip(v string) {
@@ -2416,7 +2318,6 @@ func (p *UpdatePortForwardingRuleParams) SetVmguestip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmguestip"] = v
-	return
 }
 
 // You should always use this function to get a new UpdatePortForwardingRuleParams instance,

--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -57,7 +57,6 @@ func (p *AddGuestOsParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *AddGuestOsParams) SetName(v string) {
@@ -65,7 +64,6 @@ func (p *AddGuestOsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *AddGuestOsParams) SetOscategoryid(v string) {
@@ -73,7 +71,6 @@ func (p *AddGuestOsParams) SetOscategoryid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["oscategoryid"] = v
-	return
 }
 
 func (p *AddGuestOsParams) SetOsdisplayname(v string) {
@@ -81,7 +78,6 @@ func (p *AddGuestOsParams) SetOsdisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osdisplayname"] = v
-	return
 }
 
 // You should always use this function to get a new AddGuestOsParams instance,
@@ -171,7 +167,6 @@ func (p *AddGuestOsMappingParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *AddGuestOsMappingParams) SetHypervisorversion(v string) {
@@ -179,7 +174,6 @@ func (p *AddGuestOsMappingParams) SetHypervisorversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisorversion"] = v
-	return
 }
 
 func (p *AddGuestOsMappingParams) SetOsdisplayname(v string) {
@@ -187,7 +181,6 @@ func (p *AddGuestOsMappingParams) SetOsdisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osdisplayname"] = v
-	return
 }
 
 func (p *AddGuestOsMappingParams) SetOsnameforhypervisor(v string) {
@@ -195,7 +188,6 @@ func (p *AddGuestOsMappingParams) SetOsnameforhypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osnameforhypervisor"] = v
-	return
 }
 
 func (p *AddGuestOsMappingParams) SetOstypeid(v string) {
@@ -203,7 +195,6 @@ func (p *AddGuestOsMappingParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 // You should always use this function to get a new AddGuestOsMappingParams instance,
@@ -331,7 +322,6 @@ func (p *ListGuestOsMappingParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListGuestOsMappingParams) SetHypervisorversion(v string) {
@@ -339,7 +329,6 @@ func (p *ListGuestOsMappingParams) SetHypervisorversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisorversion"] = v
-	return
 }
 
 func (p *ListGuestOsMappingParams) SetId(v string) {
@@ -347,7 +336,6 @@ func (p *ListGuestOsMappingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListGuestOsMappingParams) SetKeyword(v string) {
@@ -355,7 +343,6 @@ func (p *ListGuestOsMappingParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListGuestOsMappingParams) SetOstypeid(v string) {
@@ -363,7 +350,6 @@ func (p *ListGuestOsMappingParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *ListGuestOsMappingParams) SetPage(v int) {
@@ -371,7 +357,6 @@ func (p *ListGuestOsMappingParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListGuestOsMappingParams) SetPagesize(v int) {
@@ -379,7 +364,6 @@ func (p *ListGuestOsMappingParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListGuestOsMappingParams instance,
@@ -516,7 +500,6 @@ func (p *ListOsCategoriesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListOsCategoriesParams) SetKeyword(v string) {
@@ -524,7 +507,6 @@ func (p *ListOsCategoriesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListOsCategoriesParams) SetName(v string) {
@@ -532,7 +514,6 @@ func (p *ListOsCategoriesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListOsCategoriesParams) SetPage(v int) {
@@ -540,7 +521,6 @@ func (p *ListOsCategoriesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListOsCategoriesParams) SetPagesize(v int) {
@@ -548,7 +528,6 @@ func (p *ListOsCategoriesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListOsCategoriesParams instance,
@@ -706,7 +685,6 @@ func (p *ListOsTypesParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *ListOsTypesParams) SetId(v string) {
@@ -714,7 +692,6 @@ func (p *ListOsTypesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListOsTypesParams) SetKeyword(v string) {
@@ -722,7 +699,6 @@ func (p *ListOsTypesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListOsTypesParams) SetOscategoryid(v string) {
@@ -730,7 +706,6 @@ func (p *ListOsTypesParams) SetOscategoryid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["oscategoryid"] = v
-	return
 }
 
 func (p *ListOsTypesParams) SetPage(v int) {
@@ -738,7 +713,6 @@ func (p *ListOsTypesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListOsTypesParams) SetPagesize(v int) {
@@ -746,7 +720,6 @@ func (p *ListOsTypesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListOsTypesParams instance,
@@ -839,7 +812,6 @@ func (p *RemoveGuestOsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveGuestOsParams instance,
@@ -908,7 +880,6 @@ func (p *RemoveGuestOsMappingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveGuestOsMappingParams instance,
@@ -987,7 +958,6 @@ func (p *UpdateGuestOsParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *UpdateGuestOsParams) SetId(v string) {
@@ -995,7 +965,6 @@ func (p *UpdateGuestOsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateGuestOsParams) SetOsdisplayname(v string) {
@@ -1003,7 +972,6 @@ func (p *UpdateGuestOsParams) SetOsdisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osdisplayname"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateGuestOsParams instance,
@@ -1084,7 +1052,6 @@ func (p *UpdateGuestOsMappingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateGuestOsMappingParams) SetOsnameforhypervisor(v string) {
@@ -1092,7 +1059,6 @@ func (p *UpdateGuestOsMappingParams) SetOsnameforhypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osnameforhypervisor"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateGuestOsMappingParams instance,

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -75,7 +75,6 @@ func (p *AddBaremetalHostParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetClusterid(v string) {
@@ -83,7 +82,6 @@ func (p *AddBaremetalHostParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetClustername(v string) {
@@ -91,7 +89,6 @@ func (p *AddBaremetalHostParams) SetClustername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustername"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetHosttags(v []string) {
@@ -99,7 +96,6 @@ func (p *AddBaremetalHostParams) SetHosttags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hosttags"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetHypervisor(v string) {
@@ -107,7 +103,6 @@ func (p *AddBaremetalHostParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetIpaddress(v string) {
@@ -115,7 +110,6 @@ func (p *AddBaremetalHostParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetPassword(v string) {
@@ -123,7 +117,6 @@ func (p *AddBaremetalHostParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetPodid(v string) {
@@ -131,7 +124,6 @@ func (p *AddBaremetalHostParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetUrl(v string) {
@@ -139,7 +131,6 @@ func (p *AddBaremetalHostParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetUsername(v string) {
@@ -147,7 +138,6 @@ func (p *AddBaremetalHostParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 func (p *AddBaremetalHostParams) SetZoneid(v string) {
@@ -155,7 +145,6 @@ func (p *AddBaremetalHostParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddBaremetalHostParams instance,
@@ -289,7 +278,6 @@ func (p *AddGloboDnsHostParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddGloboDnsHostParams) SetPhysicalnetworkid(v string) {
@@ -297,7 +285,6 @@ func (p *AddGloboDnsHostParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddGloboDnsHostParams) SetUrl(v string) {
@@ -305,7 +292,6 @@ func (p *AddGloboDnsHostParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddGloboDnsHostParams) SetUsername(v string) {
@@ -313,7 +299,6 @@ func (p *AddGloboDnsHostParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddGloboDnsHostParams instance,
@@ -413,7 +398,6 @@ func (p *AddHostParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *AddHostParams) SetClusterid(v string) {
@@ -421,7 +405,6 @@ func (p *AddHostParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *AddHostParams) SetClustername(v string) {
@@ -429,7 +412,6 @@ func (p *AddHostParams) SetClustername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustername"] = v
-	return
 }
 
 func (p *AddHostParams) SetHosttags(v []string) {
@@ -437,7 +419,6 @@ func (p *AddHostParams) SetHosttags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hosttags"] = v
-	return
 }
 
 func (p *AddHostParams) SetHypervisor(v string) {
@@ -445,7 +426,6 @@ func (p *AddHostParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *AddHostParams) SetPassword(v string) {
@@ -453,7 +433,6 @@ func (p *AddHostParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddHostParams) SetPodid(v string) {
@@ -461,7 +440,6 @@ func (p *AddHostParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *AddHostParams) SetUrl(v string) {
@@ -469,7 +447,6 @@ func (p *AddHostParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddHostParams) SetUsername(v string) {
@@ -477,7 +454,6 @@ func (p *AddHostParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 func (p *AddHostParams) SetZoneid(v string) {
@@ -485,7 +461,6 @@ func (p *AddHostParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddHostParams instance,
@@ -613,7 +588,6 @@ func (p *AddSecondaryStorageParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddSecondaryStorageParams) SetZoneid(v string) {
@@ -621,7 +595,6 @@ func (p *AddSecondaryStorageParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddSecondaryStorageParams instance,
@@ -681,7 +654,6 @@ func (p *CancelHostMaintenanceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new CancelHostMaintenanceParams instance,
@@ -827,7 +799,6 @@ func (p *DedicateHostParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DedicateHostParams) SetDomainid(v string) {
@@ -835,7 +806,6 @@ func (p *DedicateHostParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DedicateHostParams) SetHostid(v string) {
@@ -843,7 +813,6 @@ func (p *DedicateHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 // You should always use this function to get a new DedicateHostParams instance,
@@ -930,7 +899,6 @@ func (p *DeleteHostParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *DeleteHostParams) SetForcedestroylocalstorage(v bool) {
@@ -938,7 +906,6 @@ func (p *DeleteHostParams) SetForcedestroylocalstorage(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forcedestroylocalstorage"] = v
-	return
 }
 
 func (p *DeleteHostParams) SetId(v string) {
@@ -946,7 +913,6 @@ func (p *DeleteHostParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteHostParams instance,
@@ -1027,7 +993,6 @@ func (p *DisableOutOfBandManagementForHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 // You should always use this function to get a new DisableOutOfBandManagementForHostParams instance,
@@ -1110,7 +1075,6 @@ func (p *EnableOutOfBandManagementForHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 // You should always use this function to get a new EnableOutOfBandManagementForHostParams instance,
@@ -1204,7 +1168,6 @@ func (p *FindHostsForMigrationParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *FindHostsForMigrationParams) SetPage(v int) {
@@ -1212,7 +1175,6 @@ func (p *FindHostsForMigrationParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *FindHostsForMigrationParams) SetPagesize(v int) {
@@ -1220,7 +1182,6 @@ func (p *FindHostsForMigrationParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *FindHostsForMigrationParams) SetVirtualmachineid(v string) {
@@ -1228,7 +1189,6 @@ func (p *FindHostsForMigrationParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new FindHostsForMigrationParams instance,
@@ -1345,7 +1305,6 @@ func (p *ListDedicatedHostsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListDedicatedHostsParams) SetAffinitygroupid(v string) {
@@ -1353,7 +1312,6 @@ func (p *ListDedicatedHostsParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
-	return
 }
 
 func (p *ListDedicatedHostsParams) SetDomainid(v string) {
@@ -1361,7 +1319,6 @@ func (p *ListDedicatedHostsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListDedicatedHostsParams) SetHostid(v string) {
@@ -1369,7 +1326,6 @@ func (p *ListDedicatedHostsParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ListDedicatedHostsParams) SetKeyword(v string) {
@@ -1377,7 +1333,6 @@ func (p *ListDedicatedHostsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDedicatedHostsParams) SetPage(v int) {
@@ -1385,7 +1340,6 @@ func (p *ListDedicatedHostsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDedicatedHostsParams) SetPagesize(v int) {
@@ -1393,7 +1347,6 @@ func (p *ListDedicatedHostsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListDedicatedHostsParams instance,
@@ -1463,7 +1416,6 @@ func (p *ListHostTagsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListHostTagsParams) SetPage(v int) {
@@ -1471,7 +1423,6 @@ func (p *ListHostTagsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListHostTagsParams) SetPagesize(v int) {
@@ -1479,7 +1430,6 @@ func (p *ListHostTagsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListHostTagsParams instance,
@@ -1627,7 +1577,6 @@ func (p *ListHostsParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListHostsParams) SetDetails(v []string) {
@@ -1635,7 +1584,6 @@ func (p *ListHostsParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ListHostsParams) SetHahost(v bool) {
@@ -1643,7 +1591,6 @@ func (p *ListHostsParams) SetHahost(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hahost"] = v
-	return
 }
 
 func (p *ListHostsParams) SetHypervisor(v string) {
@@ -1651,7 +1598,6 @@ func (p *ListHostsParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListHostsParams) SetId(v string) {
@@ -1659,7 +1605,6 @@ func (p *ListHostsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListHostsParams) SetKeyword(v string) {
@@ -1667,7 +1612,6 @@ func (p *ListHostsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListHostsParams) SetName(v string) {
@@ -1675,7 +1619,6 @@ func (p *ListHostsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListHostsParams) SetOutofbandmanagementenabled(v bool) {
@@ -1683,7 +1626,6 @@ func (p *ListHostsParams) SetOutofbandmanagementenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["outofbandmanagementenabled"] = v
-	return
 }
 
 func (p *ListHostsParams) SetOutofbandmanagementpowerstate(v string) {
@@ -1691,7 +1633,6 @@ func (p *ListHostsParams) SetOutofbandmanagementpowerstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["outofbandmanagementpowerstate"] = v
-	return
 }
 
 func (p *ListHostsParams) SetPage(v int) {
@@ -1699,7 +1640,6 @@ func (p *ListHostsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListHostsParams) SetPagesize(v int) {
@@ -1707,7 +1647,6 @@ func (p *ListHostsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListHostsParams) SetPodid(v string) {
@@ -1715,7 +1654,6 @@ func (p *ListHostsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListHostsParams) SetResourcestate(v string) {
@@ -1723,7 +1661,6 @@ func (p *ListHostsParams) SetResourcestate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcestate"] = v
-	return
 }
 
 func (p *ListHostsParams) SetState(v string) {
@@ -1731,7 +1668,6 @@ func (p *ListHostsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListHostsParams) SetType(v string) {
@@ -1739,7 +1675,6 @@ func (p *ListHostsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *ListHostsParams) SetVirtualmachineid(v string) {
@@ -1747,7 +1682,6 @@ func (p *ListHostsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *ListHostsParams) SetZoneid(v string) {
@@ -1755,7 +1689,6 @@ func (p *ListHostsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListHostsParams instance,
@@ -1962,7 +1895,6 @@ func (p *PrepareHostForMaintenanceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new PrepareHostForMaintenanceParams instance,
@@ -2102,7 +2034,6 @@ func (p *ReconnectHostParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ReconnectHostParams instance,
@@ -2242,7 +2173,6 @@ func (p *ReleaseDedicatedHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 // You should always use this function to get a new ReleaseDedicatedHostParams instance,
@@ -2311,7 +2241,6 @@ func (p *ReleaseHostReservationParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ReleaseHostReservationParams instance,
@@ -2396,7 +2325,6 @@ func (p *UpdateHostParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *UpdateHostParams) SetAnnotation(v string) {
@@ -2404,7 +2332,6 @@ func (p *UpdateHostParams) SetAnnotation(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["annotation"] = v
-	return
 }
 
 func (p *UpdateHostParams) SetHosttags(v []string) {
@@ -2412,7 +2339,6 @@ func (p *UpdateHostParams) SetHosttags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hosttags"] = v
-	return
 }
 
 func (p *UpdateHostParams) SetId(v string) {
@@ -2420,7 +2346,6 @@ func (p *UpdateHostParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateHostParams) SetOscategoryid(v string) {
@@ -2428,7 +2353,6 @@ func (p *UpdateHostParams) SetOscategoryid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["oscategoryid"] = v
-	return
 }
 
 func (p *UpdateHostParams) SetUrl(v string) {
@@ -2436,7 +2360,6 @@ func (p *UpdateHostParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateHostParams instance,
@@ -2569,7 +2492,6 @@ func (p *UpdateHostPasswordParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *UpdateHostPasswordParams) SetHostid(v string) {
@@ -2577,7 +2499,6 @@ func (p *UpdateHostPasswordParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *UpdateHostPasswordParams) SetPassword(v string) {
@@ -2585,7 +2506,6 @@ func (p *UpdateHostPasswordParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *UpdateHostPasswordParams) SetUpdate_passwd_on_host(v bool) {
@@ -2593,7 +2513,6 @@ func (p *UpdateHostPasswordParams) SetUpdate_passwd_on_host(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["update_passwd_on_host"] = v
-	return
 }
 
 func (p *UpdateHostPasswordParams) SetUsername(v string) {
@@ -2601,7 +2520,6 @@ func (p *UpdateHostPasswordParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateHostPasswordParams instance,

--- a/cloudstack/HypervisorService.go
+++ b/cloudstack/HypervisorService.go
@@ -58,7 +58,6 @@ func (p *ListHypervisorCapabilitiesParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListHypervisorCapabilitiesParams) SetId(v string) {
@@ -66,7 +65,6 @@ func (p *ListHypervisorCapabilitiesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListHypervisorCapabilitiesParams) SetKeyword(v string) {
@@ -74,7 +72,6 @@ func (p *ListHypervisorCapabilitiesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListHypervisorCapabilitiesParams) SetPage(v int) {
@@ -82,7 +79,6 @@ func (p *ListHypervisorCapabilitiesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListHypervisorCapabilitiesParams) SetPagesize(v int) {
@@ -90,7 +86,6 @@ func (p *ListHypervisorCapabilitiesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListHypervisorCapabilitiesParams instance,
@@ -187,7 +182,6 @@ func (p *ListHypervisorsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListHypervisorsParams instance,
@@ -252,7 +246,6 @@ func (p *UpdateHypervisorCapabilitiesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateHypervisorCapabilitiesParams) SetMaxguestslimit(v int64) {
@@ -260,7 +253,6 @@ func (p *UpdateHypervisorCapabilitiesParams) SetMaxguestslimit(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxguestslimit"] = v
-	return
 }
 
 func (p *UpdateHypervisorCapabilitiesParams) SetSecuritygroupenabled(v bool) {
@@ -268,7 +260,6 @@ func (p *UpdateHypervisorCapabilitiesParams) SetSecuritygroupenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupenabled"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateHypervisorCapabilitiesParams instance,

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -47,7 +47,6 @@ func (p *AttachIsoParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *AttachIsoParams) SetVirtualmachineid(v string) {
@@ -55,7 +54,6 @@ func (p *AttachIsoParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new AttachIsoParams instance,
@@ -270,7 +268,6 @@ func (p *CopyIsoParams) SetDestzoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destzoneid"] = v
-	return
 }
 
 func (p *CopyIsoParams) SetDestzoneids(v []string) {
@@ -278,7 +275,6 @@ func (p *CopyIsoParams) SetDestzoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destzoneids"] = v
-	return
 }
 
 func (p *CopyIsoParams) SetId(v string) {
@@ -286,7 +282,6 @@ func (p *CopyIsoParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *CopyIsoParams) SetSourcezoneid(v string) {
@@ -294,7 +289,6 @@ func (p *CopyIsoParams) SetSourcezoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcezoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CopyIsoParams instance,
@@ -438,7 +432,6 @@ func (p *DeleteIsoParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DeleteIsoParams) SetZoneid(v string) {
@@ -446,7 +439,6 @@ func (p *DeleteIsoParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteIsoParams instance,
@@ -515,7 +507,6 @@ func (p *DetachIsoParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new DetachIsoParams instance,
@@ -728,7 +719,6 @@ func (p *ExtractIsoParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ExtractIsoParams) SetMode(v string) {
@@ -736,7 +726,6 @@ func (p *ExtractIsoParams) SetMode(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mode"] = v
-	return
 }
 
 func (p *ExtractIsoParams) SetUrl(v string) {
@@ -744,7 +733,6 @@ func (p *ExtractIsoParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *ExtractIsoParams) SetZoneid(v string) {
@@ -752,7 +740,6 @@ func (p *ExtractIsoParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ExtractIsoParams instance,
@@ -839,7 +826,6 @@ func (p *ListIsoPermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ListIsoPermissionsParams instance,
@@ -997,7 +983,6 @@ func (p *ListIsosParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListIsosParams) SetBootable(v bool) {
@@ -1005,7 +990,6 @@ func (p *ListIsosParams) SetBootable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootable"] = v
-	return
 }
 
 func (p *ListIsosParams) SetDomainid(v string) {
@@ -1013,7 +997,6 @@ func (p *ListIsosParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListIsosParams) SetHypervisor(v string) {
@@ -1021,7 +1004,6 @@ func (p *ListIsosParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListIsosParams) SetId(v string) {
@@ -1029,7 +1011,6 @@ func (p *ListIsosParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListIsosParams) SetIsofilter(v string) {
@@ -1037,7 +1018,6 @@ func (p *ListIsosParams) SetIsofilter(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isofilter"] = v
-	return
 }
 
 func (p *ListIsosParams) SetIspublic(v bool) {
@@ -1045,7 +1025,6 @@ func (p *ListIsosParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *ListIsosParams) SetIsready(v bool) {
@@ -1053,7 +1032,6 @@ func (p *ListIsosParams) SetIsready(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isready"] = v
-	return
 }
 
 func (p *ListIsosParams) SetIsrecursive(v bool) {
@@ -1061,7 +1039,6 @@ func (p *ListIsosParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListIsosParams) SetKeyword(v string) {
@@ -1069,7 +1046,6 @@ func (p *ListIsosParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListIsosParams) SetListall(v bool) {
@@ -1077,7 +1053,6 @@ func (p *ListIsosParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListIsosParams) SetName(v string) {
@@ -1085,7 +1060,6 @@ func (p *ListIsosParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListIsosParams) SetPage(v int) {
@@ -1093,7 +1067,6 @@ func (p *ListIsosParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListIsosParams) SetPagesize(v int) {
@@ -1101,7 +1074,6 @@ func (p *ListIsosParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListIsosParams) SetProjectid(v string) {
@@ -1109,7 +1081,6 @@ func (p *ListIsosParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListIsosParams) SetShowremoved(v bool) {
@@ -1117,7 +1088,6 @@ func (p *ListIsosParams) SetShowremoved(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showremoved"] = v
-	return
 }
 
 func (p *ListIsosParams) SetTags(v map[string]string) {
@@ -1125,7 +1095,6 @@ func (p *ListIsosParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListIsosParams) SetZoneid(v string) {
@@ -1133,7 +1102,6 @@ func (p *ListIsosParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListIsosParams instance,
@@ -1398,7 +1366,6 @@ func (p *RegisterIsoParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetBootable(v bool) {
@@ -1406,7 +1373,6 @@ func (p *RegisterIsoParams) SetBootable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootable"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetChecksum(v string) {
@@ -1414,7 +1380,6 @@ func (p *RegisterIsoParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetDirectdownload(v bool) {
@@ -1422,7 +1387,6 @@ func (p *RegisterIsoParams) SetDirectdownload(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["directdownload"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetDisplaytext(v string) {
@@ -1430,7 +1394,6 @@ func (p *RegisterIsoParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetDomainid(v string) {
@@ -1438,7 +1401,6 @@ func (p *RegisterIsoParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetImagestoreuuid(v string) {
@@ -1446,7 +1408,6 @@ func (p *RegisterIsoParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetIsdynamicallyscalable(v bool) {
@@ -1454,7 +1415,6 @@ func (p *RegisterIsoParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetIsextractable(v bool) {
@@ -1462,7 +1422,6 @@ func (p *RegisterIsoParams) SetIsextractable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isextractable"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetIsfeatured(v bool) {
@@ -1470,7 +1429,6 @@ func (p *RegisterIsoParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetIspublic(v bool) {
@@ -1478,7 +1436,6 @@ func (p *RegisterIsoParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetName(v string) {
@@ -1486,7 +1443,6 @@ func (p *RegisterIsoParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetOstypeid(v string) {
@@ -1494,7 +1450,6 @@ func (p *RegisterIsoParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetPasswordenabled(v bool) {
@@ -1502,7 +1457,6 @@ func (p *RegisterIsoParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetProjectid(v string) {
@@ -1510,7 +1464,6 @@ func (p *RegisterIsoParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetUrl(v string) {
@@ -1518,7 +1471,6 @@ func (p *RegisterIsoParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *RegisterIsoParams) SetZoneid(v string) {
@@ -1526,7 +1478,6 @@ func (p *RegisterIsoParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new RegisterIsoParams instance,
@@ -1700,7 +1651,6 @@ func (p *UpdateIsoParams) SetBootable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootable"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetCleanupdetails(v bool) {
@@ -1708,7 +1658,6 @@ func (p *UpdateIsoParams) SetCleanupdetails(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanupdetails"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetDetails(v map[string]string) {
@@ -1716,7 +1665,6 @@ func (p *UpdateIsoParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetDisplaytext(v string) {
@@ -1724,7 +1672,6 @@ func (p *UpdateIsoParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetFormat(v string) {
@@ -1732,7 +1679,6 @@ func (p *UpdateIsoParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetId(v string) {
@@ -1740,7 +1686,6 @@ func (p *UpdateIsoParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetIsdynamicallyscalable(v bool) {
@@ -1748,7 +1693,6 @@ func (p *UpdateIsoParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetIsrouting(v bool) {
@@ -1756,7 +1700,6 @@ func (p *UpdateIsoParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetName(v string) {
@@ -1764,7 +1707,6 @@ func (p *UpdateIsoParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetOstypeid(v string) {
@@ -1772,7 +1714,6 @@ func (p *UpdateIsoParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetPasswordenabled(v bool) {
@@ -1780,7 +1721,6 @@ func (p *UpdateIsoParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetRequireshvm(v bool) {
@@ -1788,7 +1728,6 @@ func (p *UpdateIsoParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetSortkey(v int) {
@@ -1796,7 +1735,6 @@ func (p *UpdateIsoParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
-	return
 }
 
 func (p *UpdateIsoParams) SetSshkeyenabled(v bool) {
@@ -1804,7 +1742,6 @@ func (p *UpdateIsoParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateIsoParams instance,
@@ -1948,7 +1885,6 @@ func (p *UpdateIsoPermissionsParams) SetAccounts(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounts"] = v
-	return
 }
 
 func (p *UpdateIsoPermissionsParams) SetId(v string) {
@@ -1956,7 +1892,6 @@ func (p *UpdateIsoPermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateIsoPermissionsParams) SetIsextractable(v bool) {
@@ -1964,7 +1899,6 @@ func (p *UpdateIsoPermissionsParams) SetIsextractable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isextractable"] = v
-	return
 }
 
 func (p *UpdateIsoPermissionsParams) SetIsfeatured(v bool) {
@@ -1972,7 +1906,6 @@ func (p *UpdateIsoPermissionsParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
-	return
 }
 
 func (p *UpdateIsoPermissionsParams) SetIspublic(v bool) {
@@ -1980,7 +1913,6 @@ func (p *UpdateIsoPermissionsParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *UpdateIsoPermissionsParams) SetOp(v string) {
@@ -1988,7 +1920,6 @@ func (p *UpdateIsoPermissionsParams) SetOp(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["op"] = v
-	return
 }
 
 func (p *UpdateIsoPermissionsParams) SetProjectids(v []string) {
@@ -1996,7 +1927,6 @@ func (p *UpdateIsoPermissionsParams) SetProjectids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectids"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateIsoPermissionsParams instance,

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -60,7 +60,6 @@ func (p *AddImageStoreParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *AddImageStoreParams) SetName(v string) {
@@ -68,7 +67,6 @@ func (p *AddImageStoreParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *AddImageStoreParams) SetProvider(v string) {
@@ -76,7 +74,6 @@ func (p *AddImageStoreParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *AddImageStoreParams) SetUrl(v string) {
@@ -84,7 +81,6 @@ func (p *AddImageStoreParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddImageStoreParams) SetZoneid(v string) {
@@ -92,7 +88,6 @@ func (p *AddImageStoreParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddImageStoreParams instance,
@@ -188,7 +183,6 @@ func (p *AddImageStoreS3Params) SetAccesskey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accesskey"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetBucket(v string) {
@@ -196,7 +190,6 @@ func (p *AddImageStoreS3Params) SetBucket(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bucket"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetConnectiontimeout(v int) {
@@ -204,7 +197,6 @@ func (p *AddImageStoreS3Params) SetConnectiontimeout(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["connectiontimeout"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetConnectionttl(v int) {
@@ -212,7 +204,6 @@ func (p *AddImageStoreS3Params) SetConnectionttl(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["connectionttl"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetEndpoint(v string) {
@@ -220,7 +211,6 @@ func (p *AddImageStoreS3Params) SetEndpoint(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endpoint"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetMaxerrorretry(v int) {
@@ -228,7 +218,6 @@ func (p *AddImageStoreS3Params) SetMaxerrorretry(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxerrorretry"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetS3signer(v string) {
@@ -236,7 +225,6 @@ func (p *AddImageStoreS3Params) SetS3signer(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["s3signer"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetSecretkey(v string) {
@@ -244,7 +232,6 @@ func (p *AddImageStoreS3Params) SetSecretkey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["secretkey"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetSockettimeout(v int) {
@@ -252,7 +239,6 @@ func (p *AddImageStoreS3Params) SetSockettimeout(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sockettimeout"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetUsehttps(v bool) {
@@ -260,7 +246,6 @@ func (p *AddImageStoreS3Params) SetUsehttps(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usehttps"] = v
-	return
 }
 
 func (p *AddImageStoreS3Params) SetUsetcpkeepalive(v bool) {
@@ -268,7 +253,6 @@ func (p *AddImageStoreS3Params) SetUsetcpkeepalive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usetcpkeepalive"] = v
-	return
 }
 
 // You should always use this function to get a new AddImageStoreS3Params instance,
@@ -347,7 +331,6 @@ func (p *CreateSecondaryStagingStoreParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *CreateSecondaryStagingStoreParams) SetProvider(v string) {
@@ -355,7 +338,6 @@ func (p *CreateSecondaryStagingStoreParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *CreateSecondaryStagingStoreParams) SetScope(v string) {
@@ -363,7 +345,6 @@ func (p *CreateSecondaryStagingStoreParams) SetScope(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scope"] = v
-	return
 }
 
 func (p *CreateSecondaryStagingStoreParams) SetUrl(v string) {
@@ -371,7 +352,6 @@ func (p *CreateSecondaryStagingStoreParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *CreateSecondaryStagingStoreParams) SetZoneid(v string) {
@@ -379,7 +359,6 @@ func (p *CreateSecondaryStagingStoreParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateSecondaryStagingStoreParams instance,
@@ -439,7 +418,6 @@ func (p *DeleteImageStoreParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteImageStoreParams instance,
@@ -520,7 +498,6 @@ func (p *DeleteSecondaryStagingStoreParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteSecondaryStagingStoreParams instance,
@@ -624,7 +601,6 @@ func (p *ListImageStoresParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetKeyword(v string) {
@@ -632,7 +608,6 @@ func (p *ListImageStoresParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetName(v string) {
@@ -640,7 +615,6 @@ func (p *ListImageStoresParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetPage(v int) {
@@ -648,7 +622,6 @@ func (p *ListImageStoresParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetPagesize(v int) {
@@ -656,7 +629,6 @@ func (p *ListImageStoresParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetProtocol(v string) {
@@ -664,7 +636,6 @@ func (p *ListImageStoresParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetProvider(v string) {
@@ -672,7 +643,6 @@ func (p *ListImageStoresParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *ListImageStoresParams) SetZoneid(v string) {
@@ -680,7 +650,6 @@ func (p *ListImageStoresParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListImageStoresParams instance,
@@ -850,7 +819,6 @@ func (p *ListSecondaryStagingStoresParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetKeyword(v string) {
@@ -858,7 +826,6 @@ func (p *ListSecondaryStagingStoresParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetName(v string) {
@@ -866,7 +833,6 @@ func (p *ListSecondaryStagingStoresParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetPage(v int) {
@@ -874,7 +840,6 @@ func (p *ListSecondaryStagingStoresParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetPagesize(v int) {
@@ -882,7 +847,6 @@ func (p *ListSecondaryStagingStoresParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetProtocol(v string) {
@@ -890,7 +854,6 @@ func (p *ListSecondaryStagingStoresParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetProvider(v string) {
@@ -898,7 +861,6 @@ func (p *ListSecondaryStagingStoresParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *ListSecondaryStagingStoresParams) SetZoneid(v string) {
@@ -906,7 +868,6 @@ func (p *ListSecondaryStagingStoresParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSecondaryStagingStoresParams instance,
@@ -1066,7 +1027,6 @@ func (p *UpdateCloudToUseObjectStoreParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *UpdateCloudToUseObjectStoreParams) SetName(v string) {
@@ -1074,7 +1034,6 @@ func (p *UpdateCloudToUseObjectStoreParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateCloudToUseObjectStoreParams) SetProvider(v string) {
@@ -1082,7 +1041,6 @@ func (p *UpdateCloudToUseObjectStoreParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *UpdateCloudToUseObjectStoreParams) SetUrl(v string) {
@@ -1090,7 +1048,6 @@ func (p *UpdateCloudToUseObjectStoreParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateCloudToUseObjectStoreParams instance,

--- a/cloudstack/InternalLBService.go
+++ b/cloudstack/InternalLBService.go
@@ -48,7 +48,6 @@ func (p *ConfigureInternalLoadBalancerElementParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *ConfigureInternalLoadBalancerElementParams) SetId(v string) {
@@ -56,7 +55,6 @@ func (p *ConfigureInternalLoadBalancerElementParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ConfigureInternalLoadBalancerElementParams instance,
@@ -132,7 +130,6 @@ func (p *CreateInternalLoadBalancerElementParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateInternalLoadBalancerElementParams instance,
@@ -225,7 +222,6 @@ func (p *ListInternalLoadBalancerElementsParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerElementsParams) SetId(v string) {
@@ -233,7 +229,6 @@ func (p *ListInternalLoadBalancerElementsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerElementsParams) SetKeyword(v string) {
@@ -241,7 +236,6 @@ func (p *ListInternalLoadBalancerElementsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerElementsParams) SetNspid(v string) {
@@ -249,7 +243,6 @@ func (p *ListInternalLoadBalancerElementsParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerElementsParams) SetPage(v int) {
@@ -257,7 +250,6 @@ func (p *ListInternalLoadBalancerElementsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerElementsParams) SetPagesize(v int) {
@@ -265,7 +257,6 @@ func (p *ListInternalLoadBalancerElementsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListInternalLoadBalancerElementsParams instance,
@@ -410,7 +401,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetDomainid(v string) {
@@ -418,7 +408,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetForvpc(v bool) {
@@ -426,7 +415,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetHostid(v string) {
@@ -434,7 +422,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetId(v string) {
@@ -442,7 +429,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetIsrecursive(v bool) {
@@ -450,7 +436,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetKeyword(v string) {
@@ -458,7 +443,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetListall(v bool) {
@@ -466,7 +450,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetName(v string) {
@@ -474,7 +457,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetNetworkid(v string) {
@@ -482,7 +464,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetPage(v int) {
@@ -490,7 +471,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetPagesize(v int) {
@@ -498,7 +478,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetPodid(v string) {
@@ -506,7 +485,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetProjectid(v string) {
@@ -514,7 +492,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetState(v string) {
@@ -522,7 +499,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetVpcid(v string) {
@@ -530,7 +506,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *ListInternalLoadBalancerVMsParams) SetZoneid(v string) {
@@ -538,7 +513,6 @@ func (p *ListInternalLoadBalancerVMsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListInternalLoadBalancerVMsParams instance,
@@ -723,7 +697,6 @@ func (p *StartInternalLoadBalancerVMParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StartInternalLoadBalancerVMParams instance,
@@ -845,7 +818,6 @@ func (p *StopInternalLoadBalancerVMParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *StopInternalLoadBalancerVMParams) SetId(v string) {
@@ -853,7 +825,6 @@ func (p *StopInternalLoadBalancerVMParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StopInternalLoadBalancerVMParams instance,

--- a/cloudstack/LDAPService.go
+++ b/cloudstack/LDAPService.go
@@ -50,7 +50,6 @@ func (p *AddLdapConfigurationParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *AddLdapConfigurationParams) SetHostname(v string) {
@@ -58,7 +57,6 @@ func (p *AddLdapConfigurationParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *AddLdapConfigurationParams) SetPort(v int) {
@@ -66,7 +64,6 @@ func (p *AddLdapConfigurationParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 // You should always use this function to get a new AddLdapConfigurationParams instance,
@@ -129,7 +126,6 @@ func (p *DeleteLdapConfigurationParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DeleteLdapConfigurationParams) SetHostname(v string) {
@@ -137,7 +133,6 @@ func (p *DeleteLdapConfigurationParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *DeleteLdapConfigurationParams) SetPort(v int) {
@@ -145,7 +140,6 @@ func (p *DeleteLdapConfigurationParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteLdapConfigurationParams instance,
@@ -234,7 +228,6 @@ func (p *ImportLdapUsersParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetAccountdetails(v map[string]string) {
@@ -242,7 +235,6 @@ func (p *ImportLdapUsersParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetAccounttype(v int) {
@@ -250,7 +242,6 @@ func (p *ImportLdapUsersParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetDomainid(v string) {
@@ -258,7 +249,6 @@ func (p *ImportLdapUsersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetGroup(v string) {
@@ -266,7 +256,6 @@ func (p *ImportLdapUsersParams) SetGroup(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["group"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetKeyword(v string) {
@@ -274,7 +263,6 @@ func (p *ImportLdapUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetPage(v int) {
@@ -282,7 +270,6 @@ func (p *ImportLdapUsersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetPagesize(v int) {
@@ -290,7 +277,6 @@ func (p *ImportLdapUsersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetRoleid(v string) {
@@ -298,7 +284,6 @@ func (p *ImportLdapUsersParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 func (p *ImportLdapUsersParams) SetTimezone(v string) {
@@ -306,7 +291,6 @@ func (p *ImportLdapUsersParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
-	return
 }
 
 // You should always use this function to get a new ImportLdapUsersParams instance,
@@ -393,7 +377,6 @@ func (p *LdapConfigParams) SetBinddn(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["binddn"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetBindpass(v string) {
@@ -401,7 +384,6 @@ func (p *LdapConfigParams) SetBindpass(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bindpass"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetHostname(v string) {
@@ -409,7 +391,6 @@ func (p *LdapConfigParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetListall(v bool) {
@@ -417,7 +398,6 @@ func (p *LdapConfigParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetPort(v int) {
@@ -425,7 +405,6 @@ func (p *LdapConfigParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetQueryfilter(v string) {
@@ -433,7 +412,6 @@ func (p *LdapConfigParams) SetQueryfilter(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["queryfilter"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetSearchbase(v string) {
@@ -441,7 +419,6 @@ func (p *LdapConfigParams) SetSearchbase(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["searchbase"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetSsl(v bool) {
@@ -449,7 +426,6 @@ func (p *LdapConfigParams) SetSsl(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ssl"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetTruststore(v string) {
@@ -457,7 +433,6 @@ func (p *LdapConfigParams) SetTruststore(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["truststore"] = v
-	return
 }
 
 func (p *LdapConfigParams) SetTruststorepass(v string) {
@@ -465,7 +440,6 @@ func (p *LdapConfigParams) SetTruststorepass(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["truststorepass"] = v
-	return
 }
 
 // You should always use this function to get a new LdapConfigParams instance,
@@ -555,7 +529,6 @@ func (p *LdapCreateAccountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetAccountdetails(v map[string]string) {
@@ -563,7 +536,6 @@ func (p *LdapCreateAccountParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetAccountid(v string) {
@@ -571,7 +543,6 @@ func (p *LdapCreateAccountParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetAccounttype(v int) {
@@ -579,7 +550,6 @@ func (p *LdapCreateAccountParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetDomainid(v string) {
@@ -587,7 +557,6 @@ func (p *LdapCreateAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetNetworkdomain(v string) {
@@ -595,7 +564,6 @@ func (p *LdapCreateAccountParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetRoleid(v string) {
@@ -603,7 +571,6 @@ func (p *LdapCreateAccountParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetTimezone(v string) {
@@ -611,7 +578,6 @@ func (p *LdapCreateAccountParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetUserid(v string) {
@@ -619,7 +585,6 @@ func (p *LdapCreateAccountParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
-	return
 }
 
 func (p *LdapCreateAccountParams) SetUsername(v string) {
@@ -627,7 +592,6 @@ func (p *LdapCreateAccountParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new LdapCreateAccountParams instance,
@@ -822,7 +786,6 @@ func (p *LinkDomainToLdapParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
-	return
 }
 
 func (p *LinkDomainToLdapParams) SetAdmin(v string) {
@@ -830,7 +793,6 @@ func (p *LinkDomainToLdapParams) SetAdmin(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["admin"] = v
-	return
 }
 
 func (p *LinkDomainToLdapParams) SetDomainid(v string) {
@@ -838,7 +800,6 @@ func (p *LinkDomainToLdapParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *LinkDomainToLdapParams) SetLdapdomain(v string) {
@@ -846,7 +807,6 @@ func (p *LinkDomainToLdapParams) SetLdapdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ldapdomain"] = v
-	return
 }
 
 func (p *LinkDomainToLdapParams) SetName(v string) {
@@ -854,7 +814,6 @@ func (p *LinkDomainToLdapParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *LinkDomainToLdapParams) SetType(v string) {
@@ -862,7 +821,6 @@ func (p *LinkDomainToLdapParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new LinkDomainToLdapParams instance,
@@ -940,7 +898,6 @@ func (p *ListLdapConfigurationsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListLdapConfigurationsParams) SetHostname(v string) {
@@ -948,7 +905,6 @@ func (p *ListLdapConfigurationsParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *ListLdapConfigurationsParams) SetKeyword(v string) {
@@ -956,7 +912,6 @@ func (p *ListLdapConfigurationsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLdapConfigurationsParams) SetPage(v int) {
@@ -964,7 +919,6 @@ func (p *ListLdapConfigurationsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLdapConfigurationsParams) SetPagesize(v int) {
@@ -972,7 +926,6 @@ func (p *ListLdapConfigurationsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListLdapConfigurationsParams) SetPort(v int) {
@@ -980,7 +933,6 @@ func (p *ListLdapConfigurationsParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 // You should always use this function to get a new ListLdapConfigurationsParams instance,
@@ -1050,7 +1002,6 @@ func (p *ListLdapUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLdapUsersParams) SetListtype(v string) {
@@ -1058,7 +1009,6 @@ func (p *ListLdapUsersParams) SetListtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listtype"] = v
-	return
 }
 
 func (p *ListLdapUsersParams) SetPage(v int) {
@@ -1066,7 +1016,6 @@ func (p *ListLdapUsersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLdapUsersParams) SetPagesize(v int) {
@@ -1074,7 +1023,6 @@ func (p *ListLdapUsersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListLdapUsersParams instance,
@@ -1147,7 +1095,6 @@ func (p *SearchLdapParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *SearchLdapParams) SetPage(v int) {
@@ -1155,7 +1102,6 @@ func (p *SearchLdapParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *SearchLdapParams) SetPagesize(v int) {
@@ -1163,7 +1109,6 @@ func (p *SearchLdapParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *SearchLdapParams) SetQuery(v string) {
@@ -1171,7 +1116,6 @@ func (p *SearchLdapParams) SetQuery(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["query"] = v
-	return
 }
 
 // You should always use this function to get a new SearchLdapParams instance,

--- a/cloudstack/LimitService.go
+++ b/cloudstack/LimitService.go
@@ -123,7 +123,6 @@ func (p *ListResourceLimitsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetDomainid(v string) {
@@ -131,7 +130,6 @@ func (p *ListResourceLimitsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetId(v int64) {
@@ -139,7 +137,6 @@ func (p *ListResourceLimitsParams) SetId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetIsrecursive(v bool) {
@@ -147,7 +144,6 @@ func (p *ListResourceLimitsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetKeyword(v string) {
@@ -155,7 +151,6 @@ func (p *ListResourceLimitsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetListall(v bool) {
@@ -163,7 +158,6 @@ func (p *ListResourceLimitsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetPage(v int) {
@@ -171,7 +165,6 @@ func (p *ListResourceLimitsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetPagesize(v int) {
@@ -179,7 +172,6 @@ func (p *ListResourceLimitsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetProjectid(v string) {
@@ -187,7 +179,6 @@ func (p *ListResourceLimitsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetResourcetype(v int) {
@@ -195,7 +186,6 @@ func (p *ListResourceLimitsParams) SetResourcetype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 func (p *ListResourceLimitsParams) SetResourcetypename(v string) {
@@ -203,7 +193,6 @@ func (p *ListResourceLimitsParams) SetResourcetypename(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetypename"] = v
-	return
 }
 
 // You should always use this function to get a new ListResourceLimitsParams instance,
@@ -267,7 +256,6 @@ func (p *ResetApiLimitParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 // You should always use this function to get a new ResetApiLimitParams instance,
@@ -333,7 +321,6 @@ func (p *UpdateResourceCountParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpdateResourceCountParams) SetDomainid(v string) {
@@ -341,7 +328,6 @@ func (p *UpdateResourceCountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UpdateResourceCountParams) SetProjectid(v string) {
@@ -349,7 +335,6 @@ func (p *UpdateResourceCountParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *UpdateResourceCountParams) SetResourcetype(v int) {
@@ -357,7 +342,6 @@ func (p *UpdateResourceCountParams) SetResourcetype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateResourceCountParams instance,
@@ -431,7 +415,6 @@ func (p *UpdateResourceLimitParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpdateResourceLimitParams) SetDomainid(v string) {
@@ -439,7 +422,6 @@ func (p *UpdateResourceLimitParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UpdateResourceLimitParams) SetMax(v int64) {
@@ -447,7 +429,6 @@ func (p *UpdateResourceLimitParams) SetMax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["max"] = v
-	return
 }
 
 func (p *UpdateResourceLimitParams) SetProjectid(v string) {
@@ -455,7 +436,6 @@ func (p *UpdateResourceLimitParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *UpdateResourceLimitParams) SetResourcetype(v int) {
@@ -463,7 +443,6 @@ func (p *UpdateResourceLimitParams) SetResourcetype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateResourceLimitParams instance,

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -70,7 +70,6 @@ func (p *AddNetscalerLoadBalancerParams) SetGslbprovider(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbprovider"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetGslbproviderprivateip(v string) {
@@ -78,7 +77,6 @@ func (p *AddNetscalerLoadBalancerParams) SetGslbproviderprivateip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbproviderprivateip"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetGslbproviderpublicip(v string) {
@@ -86,7 +84,6 @@ func (p *AddNetscalerLoadBalancerParams) SetGslbproviderpublicip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbproviderpublicip"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetIsexclusivegslbprovider(v bool) {
@@ -94,7 +91,6 @@ func (p *AddNetscalerLoadBalancerParams) SetIsexclusivegslbprovider(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isexclusivegslbprovider"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetNetworkdevicetype(v string) {
@@ -102,7 +98,6 @@ func (p *AddNetscalerLoadBalancerParams) SetNetworkdevicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdevicetype"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetPassword(v string) {
@@ -110,7 +105,6 @@ func (p *AddNetscalerLoadBalancerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetPhysicalnetworkid(v string) {
@@ -118,7 +112,6 @@ func (p *AddNetscalerLoadBalancerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetUrl(v string) {
@@ -126,7 +119,6 @@ func (p *AddNetscalerLoadBalancerParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddNetscalerLoadBalancerParams) SetUsername(v string) {
@@ -134,7 +126,6 @@ func (p *AddNetscalerLoadBalancerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddNetscalerLoadBalancerParams instance,
@@ -228,7 +219,6 @@ func (p *AssignCertToLoadBalancerParams) SetCertid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certid"] = v
-	return
 }
 
 func (p *AssignCertToLoadBalancerParams) SetLbruleid(v string) {
@@ -236,7 +226,6 @@ func (p *AssignCertToLoadBalancerParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 // You should always use this function to get a new AssignCertToLoadBalancerParams instance,
@@ -317,7 +306,6 @@ func (p *AssignToGlobalLoadBalancerRuleParams) SetGslblbruleweightsmap(v map[str
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslblbruleweightsmap"] = v
-	return
 }
 
 func (p *AssignToGlobalLoadBalancerRuleParams) SetId(v string) {
@@ -325,7 +313,6 @@ func (p *AssignToGlobalLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *AssignToGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []string) {
@@ -333,7 +320,6 @@ func (p *AssignToGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []strin
 		p.p = make(map[string]interface{})
 	}
 	p.p["loadbalancerrulelist"] = v
-	return
 }
 
 // You should always use this function to get a new AssignToGlobalLoadBalancerRuleParams instance,
@@ -414,7 +400,6 @@ func (p *AssignToLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *AssignToLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
@@ -422,7 +407,6 @@ func (p *AssignToLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineids"] = v
-	return
 }
 
 func (p *AssignToLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
@@ -430,7 +414,6 @@ func (p *AssignToLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmidipmap"] = v
-	return
 }
 
 // You should always use this function to get a new AssignToLoadBalancerRuleParams instance,
@@ -515,7 +498,6 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetInline(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["inline"] = v
-	return
 }
 
 func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicecapacity(v int64) {
@@ -523,7 +505,6 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicecapacity(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdevicecapacity"] = v
-	return
 }
 
 func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicededicated(v bool) {
@@ -531,7 +512,6 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicededicated(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdevicededicated"] = v
-	return
 }
 
 func (p *ConfigureNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
@@ -539,7 +519,6 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
-	return
 }
 
 func (p *ConfigureNetscalerLoadBalancerParams) SetPodids(v []string) {
@@ -547,7 +526,6 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetPodids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podids"] = v
-	return
 }
 
 // You should always use this function to get a new ConfigureNetscalerLoadBalancerParams instance,
@@ -659,7 +637,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetDescription(v string) {
@@ -667,7 +644,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetDomainid(v string) {
@@ -675,7 +651,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetGslbdomainname(v string) {
@@ -683,7 +658,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslbdomainname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbdomainname"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
@@ -691,7 +665,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslblbmethod"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetGslbservicetype(v string) {
@@ -699,7 +672,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslbservicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbservicetype"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v string) {
@@ -707,7 +679,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v st
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbstickysessionmethodname"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetName(v string) {
@@ -715,7 +686,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) SetRegionid(v int) {
@@ -723,7 +693,6 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateGlobalLoadBalancerRuleParams instance,
@@ -862,7 +831,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
@@ -870,7 +838,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetHealthythreshold(v int) {
@@ -878,7 +845,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetHealthythreshold(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["healthythreshold"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetIntervaltime(v int) {
@@ -886,7 +852,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetIntervaltime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["intervaltime"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetLbruleid(v string) {
@@ -894,7 +859,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetPingpath(v string) {
@@ -902,7 +866,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetPingpath(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingpath"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetResponsetimeout(v int) {
@@ -910,7 +873,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetResponsetimeout(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["responsetimeout"] = v
-	return
 }
 
 func (p *CreateLBHealthCheckPolicyParams) SetUnhealthythreshold(v int) {
@@ -918,7 +880,6 @@ func (p *CreateLBHealthCheckPolicyParams) SetUnhealthythreshold(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["unhealthythreshold"] = v
-	return
 }
 
 // You should always use this function to get a new CreateLBHealthCheckPolicyParams instance,
@@ -1028,7 +989,6 @@ func (p *CreateLBStickinessPolicyParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateLBStickinessPolicyParams) SetFordisplay(v bool) {
@@ -1036,7 +996,6 @@ func (p *CreateLBStickinessPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateLBStickinessPolicyParams) SetLbruleid(v string) {
@@ -1044,7 +1003,6 @@ func (p *CreateLBStickinessPolicyParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *CreateLBStickinessPolicyParams) SetMethodname(v string) {
@@ -1052,7 +1010,6 @@ func (p *CreateLBStickinessPolicyParams) SetMethodname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["methodname"] = v
-	return
 }
 
 func (p *CreateLBStickinessPolicyParams) SetName(v string) {
@@ -1060,7 +1017,6 @@ func (p *CreateLBStickinessPolicyParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateLBStickinessPolicyParams) SetParam(v map[string]string) {
@@ -1068,7 +1024,6 @@ func (p *CreateLBStickinessPolicyParams) SetParam(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["param"] = v
-	return
 }
 
 // You should always use this function to get a new CreateLBStickinessPolicyParams instance,
@@ -1191,7 +1146,6 @@ func (p *CreateLoadBalancerParams) SetAlgorithm(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["algorithm"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetDescription(v string) {
@@ -1199,7 +1153,6 @@ func (p *CreateLoadBalancerParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetFordisplay(v bool) {
@@ -1207,7 +1160,6 @@ func (p *CreateLoadBalancerParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetInstanceport(v int) {
@@ -1215,7 +1167,6 @@ func (p *CreateLoadBalancerParams) SetInstanceport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["instanceport"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetName(v string) {
@@ -1223,7 +1174,6 @@ func (p *CreateLoadBalancerParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetNetworkid(v string) {
@@ -1231,7 +1181,6 @@ func (p *CreateLoadBalancerParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetScheme(v string) {
@@ -1239,7 +1188,6 @@ func (p *CreateLoadBalancerParams) SetScheme(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scheme"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetSourceipaddress(v string) {
@@ -1247,7 +1195,6 @@ func (p *CreateLoadBalancerParams) SetSourceipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceipaddress"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetSourceipaddressnetworkid(v string) {
@@ -1255,7 +1202,6 @@ func (p *CreateLoadBalancerParams) SetSourceipaddressnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceipaddressnetworkid"] = v
-	return
 }
 
 func (p *CreateLoadBalancerParams) SetSourceport(v int) {
@@ -1263,7 +1209,6 @@ func (p *CreateLoadBalancerParams) SetSourceport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceport"] = v
-	return
 }
 
 // You should always use this function to get a new CreateLoadBalancerParams instance,
@@ -1414,7 +1359,6 @@ func (p *CreateLoadBalancerRuleParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetAlgorithm(v string) {
@@ -1422,7 +1366,6 @@ func (p *CreateLoadBalancerRuleParams) SetAlgorithm(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["algorithm"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetCidrlist(v []string) {
@@ -1430,7 +1373,6 @@ func (p *CreateLoadBalancerRuleParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetDescription(v string) {
@@ -1438,7 +1380,6 @@ func (p *CreateLoadBalancerRuleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetDomainid(v string) {
@@ -1446,7 +1387,6 @@ func (p *CreateLoadBalancerRuleParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetFordisplay(v bool) {
@@ -1454,7 +1394,6 @@ func (p *CreateLoadBalancerRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetName(v string) {
@@ -1462,7 +1401,6 @@ func (p *CreateLoadBalancerRuleParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetNetworkid(v string) {
@@ -1470,7 +1408,6 @@ func (p *CreateLoadBalancerRuleParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetOpenfirewall(v bool) {
@@ -1478,7 +1415,6 @@ func (p *CreateLoadBalancerRuleParams) SetOpenfirewall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["openfirewall"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetPrivateport(v int) {
@@ -1486,7 +1422,6 @@ func (p *CreateLoadBalancerRuleParams) SetPrivateport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateport"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetProtocol(v string) {
@@ -1494,7 +1429,6 @@ func (p *CreateLoadBalancerRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetPublicipid(v string) {
@@ -1502,7 +1436,6 @@ func (p *CreateLoadBalancerRuleParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetPublicport(v int) {
@@ -1510,7 +1443,6 @@ func (p *CreateLoadBalancerRuleParams) SetPublicport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicport"] = v
-	return
 }
 
 func (p *CreateLoadBalancerRuleParams) SetZoneid(v string) {
@@ -1518,7 +1450,6 @@ func (p *CreateLoadBalancerRuleParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateLoadBalancerRuleParams instance,
@@ -1614,7 +1545,6 @@ func (p *DeleteGlobalLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteGlobalLoadBalancerRuleParams instance,
@@ -1683,7 +1613,6 @@ func (p *DeleteLBHealthCheckPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteLBHealthCheckPolicyParams instance,
@@ -1752,7 +1681,6 @@ func (p *DeleteLBStickinessPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteLBStickinessPolicyParams instance,
@@ -1821,7 +1749,6 @@ func (p *DeleteLoadBalancerParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteLoadBalancerParams instance,
@@ -1890,7 +1817,6 @@ func (p *DeleteLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteLoadBalancerRuleParams instance,
@@ -1959,7 +1885,6 @@ func (p *DeleteNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetscalerLoadBalancerParams instance,
@@ -2028,7 +1953,6 @@ func (p *DeleteSslCertParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteSslCertParams instance,
@@ -2148,7 +2072,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetDomainid(v string) {
@@ -2156,7 +2079,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetId(v string) {
@@ -2164,7 +2086,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetIsrecursive(v bool) {
@@ -2172,7 +2093,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetKeyword(v string) {
@@ -2180,7 +2100,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetListall(v bool) {
@@ -2188,7 +2107,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetPage(v int) {
@@ -2196,7 +2114,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetPagesize(v int) {
@@ -2204,7 +2121,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetProjectid(v string) {
@@ -2212,7 +2128,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetRegionid(v int) {
@@ -2220,7 +2135,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
-	return
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) SetTags(v map[string]string) {
@@ -2228,7 +2142,6 @@ func (p *ListGlobalLoadBalancerRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListGlobalLoadBalancerRulesParams instance,
@@ -2423,7 +2336,6 @@ func (p *ListLBHealthCheckPoliciesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListLBHealthCheckPoliciesParams) SetId(v string) {
@@ -2431,7 +2343,6 @@ func (p *ListLBHealthCheckPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListLBHealthCheckPoliciesParams) SetKeyword(v string) {
@@ -2439,7 +2350,6 @@ func (p *ListLBHealthCheckPoliciesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLBHealthCheckPoliciesParams) SetLbruleid(v string) {
@@ -2447,7 +2357,6 @@ func (p *ListLBHealthCheckPoliciesParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *ListLBHealthCheckPoliciesParams) SetPage(v int) {
@@ -2455,7 +2364,6 @@ func (p *ListLBHealthCheckPoliciesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLBHealthCheckPoliciesParams) SetPagesize(v int) {
@@ -2463,7 +2371,6 @@ func (p *ListLBHealthCheckPoliciesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListLBHealthCheckPoliciesParams instance,
@@ -2588,7 +2495,6 @@ func (p *ListLBStickinessPoliciesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListLBStickinessPoliciesParams) SetId(v string) {
@@ -2596,7 +2502,6 @@ func (p *ListLBStickinessPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListLBStickinessPoliciesParams) SetKeyword(v string) {
@@ -2604,7 +2509,6 @@ func (p *ListLBStickinessPoliciesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLBStickinessPoliciesParams) SetLbruleid(v string) {
@@ -2612,7 +2516,6 @@ func (p *ListLBStickinessPoliciesParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *ListLBStickinessPoliciesParams) SetPage(v int) {
@@ -2620,7 +2523,6 @@ func (p *ListLBStickinessPoliciesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLBStickinessPoliciesParams) SetPagesize(v int) {
@@ -2628,7 +2530,6 @@ func (p *ListLBStickinessPoliciesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListLBStickinessPoliciesParams instance,
@@ -2755,7 +2656,6 @@ func (p *ListLoadBalancerRuleInstancesParams) SetApplied(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["applied"] = v
-	return
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) SetId(v string) {
@@ -2763,7 +2663,6 @@ func (p *ListLoadBalancerRuleInstancesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) SetKeyword(v string) {
@@ -2771,7 +2670,6 @@ func (p *ListLoadBalancerRuleInstancesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) SetLbvmips(v bool) {
@@ -2779,7 +2677,6 @@ func (p *ListLoadBalancerRuleInstancesParams) SetLbvmips(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbvmips"] = v
-	return
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) SetPage(v int) {
@@ -2787,7 +2684,6 @@ func (p *ListLoadBalancerRuleInstancesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) SetPagesize(v int) {
@@ -2795,7 +2691,6 @@ func (p *ListLoadBalancerRuleInstancesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListLoadBalancerRuleInstancesParams instance,
@@ -2942,7 +2837,6 @@ func (p *ListLoadBalancerRulesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetDomainid(v string) {
@@ -2950,7 +2844,6 @@ func (p *ListLoadBalancerRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetFordisplay(v bool) {
@@ -2958,7 +2851,6 @@ func (p *ListLoadBalancerRulesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetId(v string) {
@@ -2966,7 +2858,6 @@ func (p *ListLoadBalancerRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetIsrecursive(v bool) {
@@ -2974,7 +2865,6 @@ func (p *ListLoadBalancerRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetKeyword(v string) {
@@ -2982,7 +2872,6 @@ func (p *ListLoadBalancerRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetListall(v bool) {
@@ -2990,7 +2879,6 @@ func (p *ListLoadBalancerRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetName(v string) {
@@ -2998,7 +2886,6 @@ func (p *ListLoadBalancerRulesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetNetworkid(v string) {
@@ -3006,7 +2893,6 @@ func (p *ListLoadBalancerRulesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetPage(v int) {
@@ -3014,7 +2900,6 @@ func (p *ListLoadBalancerRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetPagesize(v int) {
@@ -3022,7 +2907,6 @@ func (p *ListLoadBalancerRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetProjectid(v string) {
@@ -3030,7 +2914,6 @@ func (p *ListLoadBalancerRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetPublicipid(v string) {
@@ -3038,7 +2921,6 @@ func (p *ListLoadBalancerRulesParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetTags(v map[string]string) {
@@ -3046,7 +2928,6 @@ func (p *ListLoadBalancerRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetVirtualmachineid(v string) {
@@ -3054,7 +2935,6 @@ func (p *ListLoadBalancerRulesParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *ListLoadBalancerRulesParams) SetZoneid(v string) {
@@ -3062,7 +2942,6 @@ func (p *ListLoadBalancerRulesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListLoadBalancerRulesParams instance,
@@ -3276,7 +3155,6 @@ func (p *ListLoadBalancersParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetDomainid(v string) {
@@ -3284,7 +3162,6 @@ func (p *ListLoadBalancersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetFordisplay(v bool) {
@@ -3292,7 +3169,6 @@ func (p *ListLoadBalancersParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetId(v string) {
@@ -3300,7 +3176,6 @@ func (p *ListLoadBalancersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetIsrecursive(v bool) {
@@ -3308,7 +3183,6 @@ func (p *ListLoadBalancersParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetKeyword(v string) {
@@ -3316,7 +3190,6 @@ func (p *ListLoadBalancersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetListall(v bool) {
@@ -3324,7 +3197,6 @@ func (p *ListLoadBalancersParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetName(v string) {
@@ -3332,7 +3204,6 @@ func (p *ListLoadBalancersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetNetworkid(v string) {
@@ -3340,7 +3211,6 @@ func (p *ListLoadBalancersParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetPage(v int) {
@@ -3348,7 +3218,6 @@ func (p *ListLoadBalancersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetPagesize(v int) {
@@ -3356,7 +3225,6 @@ func (p *ListLoadBalancersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetProjectid(v string) {
@@ -3364,7 +3232,6 @@ func (p *ListLoadBalancersParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetScheme(v string) {
@@ -3372,7 +3239,6 @@ func (p *ListLoadBalancersParams) SetScheme(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scheme"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetSourceipaddress(v string) {
@@ -3380,7 +3246,6 @@ func (p *ListLoadBalancersParams) SetSourceipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceipaddress"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetSourceipaddressnetworkid(v string) {
@@ -3388,7 +3253,6 @@ func (p *ListLoadBalancersParams) SetSourceipaddressnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceipaddressnetworkid"] = v
-	return
 }
 
 func (p *ListLoadBalancersParams) SetTags(v map[string]string) {
@@ -3396,7 +3260,6 @@ func (p *ListLoadBalancersParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListLoadBalancersParams instance,
@@ -3578,7 +3441,6 @@ func (p *ListNetscalerLoadBalancersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancersParams) SetLbdeviceid(v string) {
@@ -3586,7 +3448,6 @@ func (p *ListNetscalerLoadBalancersParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancersParams) SetPage(v int) {
@@ -3594,7 +3455,6 @@ func (p *ListNetscalerLoadBalancersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancersParams) SetPagesize(v int) {
@@ -3602,7 +3462,6 @@ func (p *ListNetscalerLoadBalancersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancersParams) SetPhysicalnetworkid(v string) {
@@ -3610,7 +3469,6 @@ func (p *ListNetscalerLoadBalancersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetscalerLoadBalancersParams instance,
@@ -3690,7 +3548,6 @@ func (p *ListSslCertsParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *ListSslCertsParams) SetCertid(v string) {
@@ -3698,7 +3555,6 @@ func (p *ListSslCertsParams) SetCertid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certid"] = v
-	return
 }
 
 func (p *ListSslCertsParams) SetLbruleid(v string) {
@@ -3706,7 +3562,6 @@ func (p *ListSslCertsParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 func (p *ListSslCertsParams) SetProjectid(v string) {
@@ -3714,7 +3569,6 @@ func (p *ListSslCertsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSslCertsParams instance,
@@ -3781,7 +3635,6 @@ func (p *RemoveCertFromLoadBalancerParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveCertFromLoadBalancerParams instance,
@@ -3854,7 +3707,6 @@ func (p *RemoveFromGlobalLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *RemoveFromGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []string) {
@@ -3862,7 +3714,6 @@ func (p *RemoveFromGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []str
 		p.p = make(map[string]interface{})
 	}
 	p.p["loadbalancerrulelist"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveFromGlobalLoadBalancerRuleParams instance,
@@ -3943,7 +3794,6 @@ func (p *RemoveFromLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *RemoveFromLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
@@ -3951,7 +3801,6 @@ func (p *RemoveFromLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineids"] = v
-	return
 }
 
 func (p *RemoveFromLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
@@ -3959,7 +3808,6 @@ func (p *RemoveFromLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmidipmap"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveFromLoadBalancerRuleParams instance,
@@ -4037,7 +3885,6 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *UpdateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
@@ -4045,7 +3892,6 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslblbmethod"] = v
-	return
 }
 
 func (p *UpdateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v string) {
@@ -4053,7 +3899,6 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v st
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbstickysessionmethodname"] = v
-	return
 }
 
 func (p *UpdateGlobalLoadBalancerRuleParams) SetId(v string) {
@@ -4061,7 +3906,6 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateGlobalLoadBalancerRuleParams instance,
@@ -4178,7 +4022,6 @@ func (p *UpdateLBHealthCheckPolicyParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
@@ -4186,7 +4029,6 @@ func (p *UpdateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateLBHealthCheckPolicyParams) SetId(v string) {
@@ -4194,7 +4036,6 @@ func (p *UpdateLBHealthCheckPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateLBHealthCheckPolicyParams instance,
@@ -4291,7 +4132,6 @@ func (p *UpdateLBStickinessPolicyParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateLBStickinessPolicyParams) SetFordisplay(v bool) {
@@ -4299,7 +4139,6 @@ func (p *UpdateLBStickinessPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateLBStickinessPolicyParams) SetId(v string) {
@@ -4307,7 +4146,6 @@ func (p *UpdateLBStickinessPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateLBStickinessPolicyParams instance,
@@ -4405,7 +4243,6 @@ func (p *UpdateLoadBalancerParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerParams) SetFordisplay(v bool) {
@@ -4413,7 +4250,6 @@ func (p *UpdateLoadBalancerParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerParams) SetId(v string) {
@@ -4421,7 +4257,6 @@ func (p *UpdateLoadBalancerParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateLoadBalancerParams instance,
@@ -4541,7 +4376,6 @@ func (p *UpdateLoadBalancerRuleParams) SetAlgorithm(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["algorithm"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerRuleParams) SetCustomid(v string) {
@@ -4549,7 +4383,6 @@ func (p *UpdateLoadBalancerRuleParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerRuleParams) SetDescription(v string) {
@@ -4557,7 +4390,6 @@ func (p *UpdateLoadBalancerRuleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerRuleParams) SetFordisplay(v bool) {
@@ -4565,7 +4397,6 @@ func (p *UpdateLoadBalancerRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerRuleParams) SetId(v string) {
@@ -4573,7 +4404,6 @@ func (p *UpdateLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerRuleParams) SetName(v string) {
@@ -4581,7 +4411,6 @@ func (p *UpdateLoadBalancerRuleParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateLoadBalancerRuleParams) SetProtocol(v string) {
@@ -4589,7 +4418,6 @@ func (p *UpdateLoadBalancerRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateLoadBalancerRuleParams instance,
@@ -4703,7 +4531,6 @@ func (p *UploadSslCertParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetCertchain(v string) {
@@ -4711,7 +4538,6 @@ func (p *UploadSslCertParams) SetCertchain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certchain"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetCertificate(v string) {
@@ -4719,7 +4545,6 @@ func (p *UploadSslCertParams) SetCertificate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certificate"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetDomainid(v string) {
@@ -4727,7 +4552,6 @@ func (p *UploadSslCertParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetName(v string) {
@@ -4735,7 +4559,6 @@ func (p *UploadSslCertParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetPassword(v string) {
@@ -4743,7 +4566,6 @@ func (p *UploadSslCertParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetPrivatekey(v string) {
@@ -4751,7 +4573,6 @@ func (p *UploadSslCertParams) SetPrivatekey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privatekey"] = v
-	return
 }
 
 func (p *UploadSslCertParams) SetProjectid(v string) {
@@ -4759,7 +4580,6 @@ func (p *UploadSslCertParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new UploadSslCertParams instance,

--- a/cloudstack/NATService.go
+++ b/cloudstack/NATService.go
@@ -63,7 +63,6 @@ func (p *CreateIpForwardingRuleParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreateIpForwardingRuleParams) SetEndport(v int) {
@@ -71,7 +70,6 @@ func (p *CreateIpForwardingRuleParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *CreateIpForwardingRuleParams) SetIpaddressid(v string) {
@@ -79,7 +77,6 @@ func (p *CreateIpForwardingRuleParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *CreateIpForwardingRuleParams) SetOpenfirewall(v bool) {
@@ -87,7 +84,6 @@ func (p *CreateIpForwardingRuleParams) SetOpenfirewall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["openfirewall"] = v
-	return
 }
 
 func (p *CreateIpForwardingRuleParams) SetProtocol(v string) {
@@ -95,7 +91,6 @@ func (p *CreateIpForwardingRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *CreateIpForwardingRuleParams) SetStartport(v int) {
@@ -103,7 +98,6 @@ func (p *CreateIpForwardingRuleParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 // You should always use this function to get a new CreateIpForwardingRuleParams instance,
@@ -194,7 +188,6 @@ func (p *DeleteIpForwardingRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteIpForwardingRuleParams instance,
@@ -263,7 +256,6 @@ func (p *DisableStaticNatParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 // You should always use this function to get a new DisableStaticNatParams instance,
@@ -341,7 +333,6 @@ func (p *EnableStaticNatParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *EnableStaticNatParams) SetNetworkid(v string) {
@@ -349,7 +340,6 @@ func (p *EnableStaticNatParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *EnableStaticNatParams) SetVirtualmachineid(v string) {
@@ -357,7 +347,6 @@ func (p *EnableStaticNatParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *EnableStaticNatParams) SetVmguestip(v string) {
@@ -365,7 +354,6 @@ func (p *EnableStaticNatParams) SetVmguestip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmguestip"] = v
-	return
 }
 
 // You should always use this function to get a new EnableStaticNatParams instance,
@@ -481,7 +469,6 @@ func (p *ListIpForwardingRulesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetDomainid(v string) {
@@ -489,7 +476,6 @@ func (p *ListIpForwardingRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetId(v string) {
@@ -497,7 +483,6 @@ func (p *ListIpForwardingRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetIpaddressid(v string) {
@@ -505,7 +490,6 @@ func (p *ListIpForwardingRulesParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetIsrecursive(v bool) {
@@ -513,7 +497,6 @@ func (p *ListIpForwardingRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetKeyword(v string) {
@@ -521,7 +504,6 @@ func (p *ListIpForwardingRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetListall(v bool) {
@@ -529,7 +511,6 @@ func (p *ListIpForwardingRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetPage(v int) {
@@ -537,7 +518,6 @@ func (p *ListIpForwardingRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetPagesize(v int) {
@@ -545,7 +525,6 @@ func (p *ListIpForwardingRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetProjectid(v string) {
@@ -553,7 +532,6 @@ func (p *ListIpForwardingRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListIpForwardingRulesParams) SetVirtualmachineid(v string) {
@@ -561,7 +539,6 @@ func (p *ListIpForwardingRulesParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new ListIpForwardingRulesParams instance,

--- a/cloudstack/NetworkACLService.go
+++ b/cloudstack/NetworkACLService.go
@@ -87,7 +87,6 @@ func (p *CreateNetworkACLParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetAction(v string) {
@@ -95,7 +94,6 @@ func (p *CreateNetworkACLParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetCidrlist(v []string) {
@@ -103,7 +101,6 @@ func (p *CreateNetworkACLParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetEndport(v int) {
@@ -111,7 +108,6 @@ func (p *CreateNetworkACLParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetFordisplay(v bool) {
@@ -119,7 +115,6 @@ func (p *CreateNetworkACLParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetIcmpcode(v int) {
@@ -127,7 +122,6 @@ func (p *CreateNetworkACLParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetIcmptype(v int) {
@@ -135,7 +129,6 @@ func (p *CreateNetworkACLParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetNetworkid(v string) {
@@ -143,7 +136,6 @@ func (p *CreateNetworkACLParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetNumber(v int) {
@@ -151,7 +143,6 @@ func (p *CreateNetworkACLParams) SetNumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["number"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetProtocol(v string) {
@@ -159,7 +150,6 @@ func (p *CreateNetworkACLParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetReason(v string) {
@@ -167,7 +157,6 @@ func (p *CreateNetworkACLParams) SetReason(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["reason"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetStartport(v int) {
@@ -175,7 +164,6 @@ func (p *CreateNetworkACLParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 func (p *CreateNetworkACLParams) SetTraffictype(v string) {
@@ -183,7 +171,6 @@ func (p *CreateNetworkACLParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 // You should always use this function to get a new CreateNetworkACLParams instance,
@@ -280,7 +267,6 @@ func (p *CreateNetworkACLListParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateNetworkACLListParams) SetFordisplay(v bool) {
@@ -288,7 +274,6 @@ func (p *CreateNetworkACLListParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateNetworkACLListParams) SetName(v string) {
@@ -296,7 +281,6 @@ func (p *CreateNetworkACLListParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateNetworkACLListParams) SetVpcid(v string) {
@@ -304,7 +288,6 @@ func (p *CreateNetworkACLListParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateNetworkACLListParams instance,
@@ -382,7 +365,6 @@ func (p *DeleteNetworkACLParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetworkACLParams instance,
@@ -451,7 +433,6 @@ func (p *DeleteNetworkACLListParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetworkACLListParams instance,
@@ -561,7 +542,6 @@ func (p *ListNetworkACLListsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetDomainid(v string) {
@@ -569,7 +549,6 @@ func (p *ListNetworkACLListsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetFordisplay(v bool) {
@@ -577,7 +556,6 @@ func (p *ListNetworkACLListsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetId(v string) {
@@ -585,7 +563,6 @@ func (p *ListNetworkACLListsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetIsrecursive(v bool) {
@@ -593,7 +570,6 @@ func (p *ListNetworkACLListsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetKeyword(v string) {
@@ -601,7 +577,6 @@ func (p *ListNetworkACLListsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetListall(v bool) {
@@ -609,7 +584,6 @@ func (p *ListNetworkACLListsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetName(v string) {
@@ -617,7 +591,6 @@ func (p *ListNetworkACLListsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetNetworkid(v string) {
@@ -625,7 +598,6 @@ func (p *ListNetworkACLListsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetPage(v int) {
@@ -633,7 +605,6 @@ func (p *ListNetworkACLListsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetPagesize(v int) {
@@ -641,7 +612,6 @@ func (p *ListNetworkACLListsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetProjectid(v string) {
@@ -649,7 +619,6 @@ func (p *ListNetworkACLListsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListNetworkACLListsParams) SetVpcid(v string) {
@@ -657,7 +626,6 @@ func (p *ListNetworkACLListsParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworkACLListsParams instance,
@@ -855,7 +823,6 @@ func (p *ListNetworkACLsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetAclid(v string) {
@@ -863,7 +830,6 @@ func (p *ListNetworkACLsParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetAction(v string) {
@@ -871,7 +837,6 @@ func (p *ListNetworkACLsParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetDomainid(v string) {
@@ -879,7 +844,6 @@ func (p *ListNetworkACLsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetFordisplay(v bool) {
@@ -887,7 +851,6 @@ func (p *ListNetworkACLsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetId(v string) {
@@ -895,7 +858,6 @@ func (p *ListNetworkACLsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetIsrecursive(v bool) {
@@ -903,7 +865,6 @@ func (p *ListNetworkACLsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetKeyword(v string) {
@@ -911,7 +872,6 @@ func (p *ListNetworkACLsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetListall(v bool) {
@@ -919,7 +879,6 @@ func (p *ListNetworkACLsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetNetworkid(v string) {
@@ -927,7 +886,6 @@ func (p *ListNetworkACLsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetPage(v int) {
@@ -935,7 +893,6 @@ func (p *ListNetworkACLsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetPagesize(v int) {
@@ -943,7 +900,6 @@ func (p *ListNetworkACLsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetProjectid(v string) {
@@ -951,7 +907,6 @@ func (p *ListNetworkACLsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetProtocol(v string) {
@@ -959,7 +914,6 @@ func (p *ListNetworkACLsParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetTags(v map[string]string) {
@@ -967,7 +921,6 @@ func (p *ListNetworkACLsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListNetworkACLsParams) SetTraffictype(v string) {
@@ -975,7 +928,6 @@ func (p *ListNetworkACLsParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworkACLsParams instance,
@@ -1085,7 +1037,6 @@ func (p *ReplaceNetworkACLListParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
-	return
 }
 
 func (p *ReplaceNetworkACLListParams) SetGatewayid(v string) {
@@ -1093,7 +1044,6 @@ func (p *ReplaceNetworkACLListParams) SetGatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gatewayid"] = v
-	return
 }
 
 func (p *ReplaceNetworkACLListParams) SetNetworkid(v string) {
@@ -1101,7 +1051,6 @@ func (p *ReplaceNetworkACLListParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 // You should always use this function to get a new ReplaceNetworkACLListParams instance,
@@ -1217,7 +1166,6 @@ func (p *UpdateNetworkACLItemParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetCidrlist(v []string) {
@@ -1225,7 +1173,6 @@ func (p *UpdateNetworkACLItemParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetCustomid(v string) {
@@ -1233,7 +1180,6 @@ func (p *UpdateNetworkACLItemParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetEndport(v int) {
@@ -1241,7 +1187,6 @@ func (p *UpdateNetworkACLItemParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetFordisplay(v bool) {
@@ -1249,7 +1194,6 @@ func (p *UpdateNetworkACLItemParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetIcmpcode(v int) {
@@ -1257,7 +1201,6 @@ func (p *UpdateNetworkACLItemParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetIcmptype(v int) {
@@ -1265,7 +1208,6 @@ func (p *UpdateNetworkACLItemParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetId(v string) {
@@ -1273,7 +1215,6 @@ func (p *UpdateNetworkACLItemParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetNumber(v int) {
@@ -1281,7 +1222,6 @@ func (p *UpdateNetworkACLItemParams) SetNumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["number"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetPartialupgrade(v bool) {
@@ -1289,7 +1229,6 @@ func (p *UpdateNetworkACLItemParams) SetPartialupgrade(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["partialupgrade"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetProtocol(v string) {
@@ -1297,7 +1236,6 @@ func (p *UpdateNetworkACLItemParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetReason(v string) {
@@ -1305,7 +1243,6 @@ func (p *UpdateNetworkACLItemParams) SetReason(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["reason"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetStartport(v int) {
@@ -1313,7 +1250,6 @@ func (p *UpdateNetworkACLItemParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 func (p *UpdateNetworkACLItemParams) SetTraffictype(v string) {
@@ -1321,7 +1257,6 @@ func (p *UpdateNetworkACLItemParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateNetworkACLItemParams instance,
@@ -1421,7 +1356,6 @@ func (p *UpdateNetworkACLListParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateNetworkACLListParams) SetDescription(v string) {
@@ -1429,7 +1363,6 @@ func (p *UpdateNetworkACLListParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *UpdateNetworkACLListParams) SetFordisplay(v bool) {
@@ -1437,7 +1370,6 @@ func (p *UpdateNetworkACLListParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateNetworkACLListParams) SetId(v string) {
@@ -1445,7 +1377,6 @@ func (p *UpdateNetworkACLListParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateNetworkACLListParams) SetName(v string) {
@@ -1453,7 +1384,6 @@ func (p *UpdateNetworkACLListParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateNetworkACLListParams instance,

--- a/cloudstack/NetworkDeviceService.go
+++ b/cloudstack/NetworkDeviceService.go
@@ -50,7 +50,6 @@ func (p *AddNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdeviceparameterlist"] = v
-	return
 }
 
 func (p *AddNetworkDeviceParams) SetNetworkdevicetype(v string) {
@@ -58,7 +57,6 @@ func (p *AddNetworkDeviceParams) SetNetworkdevicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdevicetype"] = v
-	return
 }
 
 // You should always use this function to get a new AddNetworkDeviceParams instance,
@@ -110,7 +108,6 @@ func (p *DeleteNetworkDeviceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetworkDeviceParams instance,
@@ -209,7 +206,6 @@ func (p *ListNetworkDeviceParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]string) {
@@ -217,7 +213,6 @@ func (p *ListNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]str
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdeviceparameterlist"] = v
-	return
 }
 
 func (p *ListNetworkDeviceParams) SetNetworkdevicetype(v string) {
@@ -225,7 +220,6 @@ func (p *ListNetworkDeviceParams) SetNetworkdevicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdevicetype"] = v
-	return
 }
 
 func (p *ListNetworkDeviceParams) SetPage(v int) {
@@ -233,7 +227,6 @@ func (p *ListNetworkDeviceParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworkDeviceParams) SetPagesize(v int) {
@@ -241,7 +234,6 @@ func (p *ListNetworkDeviceParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworkDeviceParams instance,

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -122,7 +122,6 @@ func (p *CreateNetworkOfferingParams) SetAvailability(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["availability"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetConservemode(v bool) {
@@ -130,7 +129,6 @@ func (p *CreateNetworkOfferingParams) SetConservemode(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["conservemode"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetDetails(v map[string]string) {
@@ -138,7 +136,6 @@ func (p *CreateNetworkOfferingParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetDisplaytext(v string) {
@@ -146,7 +143,6 @@ func (p *CreateNetworkOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetEgressdefaultpolicy(v bool) {
@@ -154,7 +150,6 @@ func (p *CreateNetworkOfferingParams) SetEgressdefaultpolicy(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["egressdefaultpolicy"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetForvpc(v bool) {
@@ -162,7 +157,6 @@ func (p *CreateNetworkOfferingParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetGuestiptype(v string) {
@@ -170,7 +164,6 @@ func (p *CreateNetworkOfferingParams) SetGuestiptype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestiptype"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetIspersistent(v bool) {
@@ -178,7 +171,6 @@ func (p *CreateNetworkOfferingParams) SetIspersistent(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispersistent"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
@@ -186,7 +178,6 @@ func (p *CreateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keepaliveenabled"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetMaxconnections(v int) {
@@ -194,7 +185,6 @@ func (p *CreateNetworkOfferingParams) SetMaxconnections(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxconnections"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetName(v string) {
@@ -202,7 +192,6 @@ func (p *CreateNetworkOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetNetworkrate(v int) {
@@ -210,7 +199,6 @@ func (p *CreateNetworkOfferingParams) SetNetworkrate(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkrate"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetServicecapabilitylist(v map[string]string) {
@@ -218,7 +206,6 @@ func (p *CreateNetworkOfferingParams) SetServicecapabilitylist(v map[string]stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["servicecapabilitylist"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetServiceofferingid(v string) {
@@ -226,7 +213,6 @@ func (p *CreateNetworkOfferingParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetServiceproviderlist(v map[string]string) {
@@ -234,7 +220,6 @@ func (p *CreateNetworkOfferingParams) SetServiceproviderlist(v map[string]string
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceproviderlist"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetSpecifyipranges(v bool) {
@@ -242,7 +227,6 @@ func (p *CreateNetworkOfferingParams) SetSpecifyipranges(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyipranges"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetSpecifyvlan(v bool) {
@@ -250,7 +234,6 @@ func (p *CreateNetworkOfferingParams) SetSpecifyvlan(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyvlan"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetSupportedservices(v []string) {
@@ -258,7 +241,6 @@ func (p *CreateNetworkOfferingParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetTags(v string) {
@@ -266,7 +248,6 @@ func (p *CreateNetworkOfferingParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *CreateNetworkOfferingParams) SetTraffictype(v string) {
@@ -274,7 +255,6 @@ func (p *CreateNetworkOfferingParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 // You should always use this function to get a new CreateNetworkOfferingParams instance,
@@ -379,7 +359,6 @@ func (p *DeleteNetworkOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetworkOfferingParams instance,
@@ -526,7 +505,6 @@ func (p *ListNetworkOfferingsParams) SetAvailability(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["availability"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetDisplaytext(v string) {
@@ -534,7 +512,6 @@ func (p *ListNetworkOfferingsParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetForvpc(v bool) {
@@ -542,7 +519,6 @@ func (p *ListNetworkOfferingsParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetGuestiptype(v string) {
@@ -550,7 +526,6 @@ func (p *ListNetworkOfferingsParams) SetGuestiptype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestiptype"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetId(v string) {
@@ -558,7 +533,6 @@ func (p *ListNetworkOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetIsdefault(v bool) {
@@ -566,7 +540,6 @@ func (p *ListNetworkOfferingsParams) SetIsdefault(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdefault"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetIstagged(v bool) {
@@ -574,7 +547,6 @@ func (p *ListNetworkOfferingsParams) SetIstagged(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["istagged"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetKeyword(v string) {
@@ -582,7 +554,6 @@ func (p *ListNetworkOfferingsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetName(v string) {
@@ -590,7 +561,6 @@ func (p *ListNetworkOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetNetworkid(v string) {
@@ -598,7 +568,6 @@ func (p *ListNetworkOfferingsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetPage(v int) {
@@ -606,7 +575,6 @@ func (p *ListNetworkOfferingsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetPagesize(v int) {
@@ -614,7 +582,6 @@ func (p *ListNetworkOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetSourcenatsupported(v bool) {
@@ -622,7 +589,6 @@ func (p *ListNetworkOfferingsParams) SetSourcenatsupported(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcenatsupported"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetSpecifyipranges(v bool) {
@@ -630,7 +596,6 @@ func (p *ListNetworkOfferingsParams) SetSpecifyipranges(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyipranges"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetSpecifyvlan(v bool) {
@@ -638,7 +603,6 @@ func (p *ListNetworkOfferingsParams) SetSpecifyvlan(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyvlan"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetState(v string) {
@@ -646,7 +610,6 @@ func (p *ListNetworkOfferingsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetSupportedservices(v []string) {
@@ -654,7 +617,6 @@ func (p *ListNetworkOfferingsParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetTags(v string) {
@@ -662,7 +624,6 @@ func (p *ListNetworkOfferingsParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetTraffictype(v string) {
@@ -670,7 +631,6 @@ func (p *ListNetworkOfferingsParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 func (p *ListNetworkOfferingsParams) SetZoneid(v string) {
@@ -678,7 +638,6 @@ func (p *ListNetworkOfferingsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworkOfferingsParams instance,
@@ -889,7 +848,6 @@ func (p *UpdateNetworkOfferingParams) SetAvailability(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["availability"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetDisplaytext(v string) {
@@ -897,7 +855,6 @@ func (p *UpdateNetworkOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetId(v string) {
@@ -905,7 +862,6 @@ func (p *UpdateNetworkOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
@@ -913,7 +869,6 @@ func (p *UpdateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keepaliveenabled"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetMaxconnections(v int) {
@@ -921,7 +876,6 @@ func (p *UpdateNetworkOfferingParams) SetMaxconnections(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxconnections"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetName(v string) {
@@ -929,7 +883,6 @@ func (p *UpdateNetworkOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetSortkey(v int) {
@@ -937,7 +890,6 @@ func (p *UpdateNetworkOfferingParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetState(v string) {
@@ -945,7 +897,6 @@ func (p *UpdateNetworkOfferingParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *UpdateNetworkOfferingParams) SetTags(v string) {
@@ -953,7 +904,6 @@ func (p *UpdateNetworkOfferingParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateNetworkOfferingParams instance,

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -54,7 +54,6 @@ func (p *AddNetworkServiceProviderParams) SetDestinationphysicalnetworkid(v stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["destinationphysicalnetworkid"] = v
-	return
 }
 
 func (p *AddNetworkServiceProviderParams) SetName(v string) {
@@ -62,7 +61,6 @@ func (p *AddNetworkServiceProviderParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *AddNetworkServiceProviderParams) SetPhysicalnetworkid(v string) {
@@ -70,7 +68,6 @@ func (p *AddNetworkServiceProviderParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddNetworkServiceProviderParams) SetServicelist(v []string) {
@@ -78,7 +75,6 @@ func (p *AddNetworkServiceProviderParams) SetServicelist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["servicelist"] = v
-	return
 }
 
 // You should always use this function to get a new AddNetworkServiceProviderParams instance,
@@ -167,7 +163,6 @@ func (p *AddOpenDaylightControllerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddOpenDaylightControllerParams) SetPhysicalnetworkid(v string) {
@@ -175,7 +170,6 @@ func (p *AddOpenDaylightControllerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddOpenDaylightControllerParams) SetUrl(v string) {
@@ -183,7 +177,6 @@ func (p *AddOpenDaylightControllerParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddOpenDaylightControllerParams) SetUsername(v string) {
@@ -191,7 +184,6 @@ func (p *AddOpenDaylightControllerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddOpenDaylightControllerParams instance,
@@ -349,7 +341,6 @@ func (p *CreateNetworkParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetAclid(v string) {
@@ -357,7 +348,6 @@ func (p *CreateNetworkParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetAcltype(v string) {
@@ -365,7 +355,6 @@ func (p *CreateNetworkParams) SetAcltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["acltype"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetBypassvlanoverlapcheck(v bool) {
@@ -373,7 +362,6 @@ func (p *CreateNetworkParams) SetBypassvlanoverlapcheck(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bypassvlanoverlapcheck"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetDisplaynetwork(v bool) {
@@ -381,7 +369,6 @@ func (p *CreateNetworkParams) SetDisplaynetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaynetwork"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetDisplaytext(v string) {
@@ -389,7 +376,6 @@ func (p *CreateNetworkParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetDomainid(v string) {
@@ -397,7 +383,6 @@ func (p *CreateNetworkParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetEndip(v string) {
@@ -405,7 +390,6 @@ func (p *CreateNetworkParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetEndipv6(v string) {
@@ -413,7 +397,6 @@ func (p *CreateNetworkParams) SetEndipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endipv6"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetExternalid(v string) {
@@ -421,7 +404,6 @@ func (p *CreateNetworkParams) SetExternalid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["externalid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetGateway(v string) {
@@ -429,7 +411,6 @@ func (p *CreateNetworkParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetIp6cidr(v string) {
@@ -437,7 +418,6 @@ func (p *CreateNetworkParams) SetIp6cidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6cidr"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetIp6gateway(v string) {
@@ -445,7 +425,6 @@ func (p *CreateNetworkParams) SetIp6gateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6gateway"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetIsolatedpvlan(v string) {
@@ -453,7 +432,6 @@ func (p *CreateNetworkParams) SetIsolatedpvlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isolatedpvlan"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetName(v string) {
@@ -461,7 +439,6 @@ func (p *CreateNetworkParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetNetmask(v string) {
@@ -469,7 +446,6 @@ func (p *CreateNetworkParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetNetworkdomain(v string) {
@@ -477,7 +453,6 @@ func (p *CreateNetworkParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetNetworkofferingid(v string) {
@@ -485,7 +460,6 @@ func (p *CreateNetworkParams) SetNetworkofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkofferingid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetPhysicalnetworkid(v string) {
@@ -493,7 +467,6 @@ func (p *CreateNetworkParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetProjectid(v string) {
@@ -501,7 +474,6 @@ func (p *CreateNetworkParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetStartip(v string) {
@@ -509,7 +481,6 @@ func (p *CreateNetworkParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetStartipv6(v string) {
@@ -517,7 +488,6 @@ func (p *CreateNetworkParams) SetStartipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startipv6"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetSubdomainaccess(v bool) {
@@ -525,7 +495,6 @@ func (p *CreateNetworkParams) SetSubdomainaccess(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["subdomainaccess"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetVlan(v string) {
@@ -533,7 +502,6 @@ func (p *CreateNetworkParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetVpcid(v string) {
@@ -541,7 +509,6 @@ func (p *CreateNetworkParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *CreateNetworkParams) SetZoneid(v string) {
@@ -549,7 +516,6 @@ func (p *CreateNetworkParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateNetworkParams instance,
@@ -703,7 +669,6 @@ func (p *CreatePhysicalNetworkParams) SetBroadcastdomainrange(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["broadcastdomainrange"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetDomainid(v string) {
@@ -711,7 +676,6 @@ func (p *CreatePhysicalNetworkParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetIsolationmethods(v []string) {
@@ -719,7 +683,6 @@ func (p *CreatePhysicalNetworkParams) SetIsolationmethods(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isolationmethods"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetName(v string) {
@@ -727,7 +690,6 @@ func (p *CreatePhysicalNetworkParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetNetworkspeed(v string) {
@@ -735,7 +697,6 @@ func (p *CreatePhysicalNetworkParams) SetNetworkspeed(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkspeed"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetTags(v []string) {
@@ -743,7 +704,6 @@ func (p *CreatePhysicalNetworkParams) SetTags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetVlan(v string) {
@@ -751,7 +711,6 @@ func (p *CreatePhysicalNetworkParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *CreatePhysicalNetworkParams) SetZoneid(v string) {
@@ -759,7 +718,6 @@ func (p *CreatePhysicalNetworkParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreatePhysicalNetworkParams instance,
@@ -866,7 +824,6 @@ func (p *CreateServiceInstanceParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetDomainid(v string) {
@@ -874,7 +831,6 @@ func (p *CreateServiceInstanceParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetLeftnetworkid(v string) {
@@ -882,7 +838,6 @@ func (p *CreateServiceInstanceParams) SetLeftnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["leftnetworkid"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetName(v string) {
@@ -890,7 +845,6 @@ func (p *CreateServiceInstanceParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetProjectid(v string) {
@@ -898,7 +852,6 @@ func (p *CreateServiceInstanceParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetRightnetworkid(v string) {
@@ -906,7 +859,6 @@ func (p *CreateServiceInstanceParams) SetRightnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["rightnetworkid"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetServiceofferingid(v string) {
@@ -914,7 +866,6 @@ func (p *CreateServiceInstanceParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetTemplateid(v string) {
@@ -922,7 +873,6 @@ func (p *CreateServiceInstanceParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *CreateServiceInstanceParams) SetZoneid(v string) {
@@ -930,7 +880,6 @@ func (p *CreateServiceInstanceParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateServiceInstanceParams instance,
@@ -1031,7 +980,6 @@ func (p *CreateStorageNetworkIpRangeParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *CreateStorageNetworkIpRangeParams) SetGateway(v string) {
@@ -1039,7 +987,6 @@ func (p *CreateStorageNetworkIpRangeParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreateStorageNetworkIpRangeParams) SetNetmask(v string) {
@@ -1047,7 +994,6 @@ func (p *CreateStorageNetworkIpRangeParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *CreateStorageNetworkIpRangeParams) SetPodid(v string) {
@@ -1055,7 +1001,6 @@ func (p *CreateStorageNetworkIpRangeParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *CreateStorageNetworkIpRangeParams) SetStartip(v string) {
@@ -1063,7 +1008,6 @@ func (p *CreateStorageNetworkIpRangeParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 func (p *CreateStorageNetworkIpRangeParams) SetVlan(v int) {
@@ -1071,7 +1015,6 @@ func (p *CreateStorageNetworkIpRangeParams) SetVlan(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 // You should always use this function to get a new CreateStorageNetworkIpRangeParams instance,
@@ -1164,7 +1107,6 @@ func (p *DedicatePublicIpRangeParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DedicatePublicIpRangeParams) SetDomainid(v string) {
@@ -1172,7 +1114,6 @@ func (p *DedicatePublicIpRangeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DedicatePublicIpRangeParams) SetId(v string) {
@@ -1180,7 +1121,6 @@ func (p *DedicatePublicIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DedicatePublicIpRangeParams) SetProjectid(v string) {
@@ -1188,7 +1128,6 @@ func (p *DedicatePublicIpRangeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new DedicatePublicIpRangeParams instance,
@@ -1268,7 +1207,6 @@ func (p *DeleteNetworkParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *DeleteNetworkParams) SetId(v string) {
@@ -1276,7 +1214,6 @@ func (p *DeleteNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetworkParams instance,
@@ -1345,7 +1282,6 @@ func (p *DeleteNetworkServiceProviderParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNetworkServiceProviderParams instance,
@@ -1414,7 +1350,6 @@ func (p *DeleteOpenDaylightControllerParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteOpenDaylightControllerParams instance,
@@ -1491,7 +1426,6 @@ func (p *DeletePhysicalNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeletePhysicalNetworkParams instance,
@@ -1560,7 +1494,6 @@ func (p *DeleteStorageNetworkIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteStorageNetworkIpRangeParams instance,
@@ -1640,7 +1573,6 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancerNetworksParams) SetLbdeviceid(v string) {
@@ -1648,7 +1580,6 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancerNetworksParams) SetPage(v int) {
@@ -1656,7 +1587,6 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetscalerLoadBalancerNetworksParams) SetPagesize(v int) {
@@ -1664,7 +1594,6 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetscalerLoadBalancerNetworksParams instance,
@@ -1838,7 +1767,6 @@ func (p *ListNetworkIsolationMethodsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworkIsolationMethodsParams) SetPage(v int) {
@@ -1846,7 +1774,6 @@ func (p *ListNetworkIsolationMethodsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworkIsolationMethodsParams) SetPagesize(v int) {
@@ -1854,7 +1781,6 @@ func (p *ListNetworkIsolationMethodsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworkIsolationMethodsParams instance,
@@ -1928,7 +1854,6 @@ func (p *ListNetworkServiceProvidersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworkServiceProvidersParams) SetName(v string) {
@@ -1936,7 +1861,6 @@ func (p *ListNetworkServiceProvidersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListNetworkServiceProvidersParams) SetPage(v int) {
@@ -1944,7 +1868,6 @@ func (p *ListNetworkServiceProvidersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworkServiceProvidersParams) SetPagesize(v int) {
@@ -1952,7 +1875,6 @@ func (p *ListNetworkServiceProvidersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNetworkServiceProvidersParams) SetPhysicalnetworkid(v string) {
@@ -1960,7 +1882,6 @@ func (p *ListNetworkServiceProvidersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListNetworkServiceProvidersParams) SetState(v string) {
@@ -1968,7 +1889,6 @@ func (p *ListNetworkServiceProvidersParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworkServiceProvidersParams instance,
@@ -2148,7 +2068,6 @@ func (p *ListNetworksParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetAcltype(v string) {
@@ -2156,7 +2075,6 @@ func (p *ListNetworksParams) SetAcltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["acltype"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetCanusefordeploy(v bool) {
@@ -2164,7 +2082,6 @@ func (p *ListNetworksParams) SetCanusefordeploy(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["canusefordeploy"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetDisplaynetwork(v bool) {
@@ -2172,7 +2089,6 @@ func (p *ListNetworksParams) SetDisplaynetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaynetwork"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetDomainid(v string) {
@@ -2180,7 +2096,6 @@ func (p *ListNetworksParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetForvpc(v bool) {
@@ -2188,7 +2103,6 @@ func (p *ListNetworksParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetId(v string) {
@@ -2196,7 +2110,6 @@ func (p *ListNetworksParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetIsrecursive(v bool) {
@@ -2204,7 +2117,6 @@ func (p *ListNetworksParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetIssystem(v bool) {
@@ -2212,7 +2124,6 @@ func (p *ListNetworksParams) SetIssystem(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["issystem"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetKeyword(v string) {
@@ -2220,7 +2131,6 @@ func (p *ListNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetListall(v bool) {
@@ -2228,7 +2138,6 @@ func (p *ListNetworksParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetPage(v int) {
@@ -2236,7 +2145,6 @@ func (p *ListNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetPagesize(v int) {
@@ -2244,7 +2152,6 @@ func (p *ListNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetPhysicalnetworkid(v string) {
@@ -2252,7 +2159,6 @@ func (p *ListNetworksParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetProjectid(v string) {
@@ -2260,7 +2166,6 @@ func (p *ListNetworksParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetRestartrequired(v bool) {
@@ -2268,7 +2173,6 @@ func (p *ListNetworksParams) SetRestartrequired(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["restartrequired"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetSpecifyipranges(v bool) {
@@ -2276,7 +2180,6 @@ func (p *ListNetworksParams) SetSpecifyipranges(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyipranges"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetSupportedservices(v []string) {
@@ -2284,7 +2187,6 @@ func (p *ListNetworksParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetTags(v map[string]string) {
@@ -2292,7 +2194,6 @@ func (p *ListNetworksParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetTraffictype(v string) {
@@ -2300,7 +2201,6 @@ func (p *ListNetworksParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetType(v string) {
@@ -2308,7 +2208,6 @@ func (p *ListNetworksParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetVpcid(v string) {
@@ -2316,7 +2215,6 @@ func (p *ListNetworksParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *ListNetworksParams) SetZoneid(v string) {
@@ -2324,7 +2222,6 @@ func (p *ListNetworksParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNetworksParams instance,
@@ -2546,7 +2443,6 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNiciraNvpDeviceNetworksParams) SetNvpdeviceid(v string) {
@@ -2554,7 +2450,6 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetNvpdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nvpdeviceid"] = v
-	return
 }
 
 func (p *ListNiciraNvpDeviceNetworksParams) SetPage(v int) {
@@ -2562,7 +2457,6 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNiciraNvpDeviceNetworksParams) SetPagesize(v int) {
@@ -2570,7 +2464,6 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListNiciraNvpDeviceNetworksParams instance,
@@ -2739,7 +2632,6 @@ func (p *ListOpenDaylightControllersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListOpenDaylightControllersParams) SetPhysicalnetworkid(v string) {
@@ -2747,7 +2639,6 @@ func (p *ListOpenDaylightControllersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListOpenDaylightControllersParams instance,
@@ -2852,7 +2743,6 @@ func (p *ListPaloAltoFirewallNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallNetworksParams) SetLbdeviceid(v string) {
@@ -2860,7 +2750,6 @@ func (p *ListPaloAltoFirewallNetworksParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallNetworksParams) SetPage(v int) {
@@ -2868,7 +2757,6 @@ func (p *ListPaloAltoFirewallNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPaloAltoFirewallNetworksParams) SetPagesize(v int) {
@@ -2876,7 +2764,6 @@ func (p *ListPaloAltoFirewallNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListPaloAltoFirewallNetworksParams instance,
@@ -3059,7 +2946,6 @@ func (p *ListPhysicalNetworksParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListPhysicalNetworksParams) SetKeyword(v string) {
@@ -3067,7 +2953,6 @@ func (p *ListPhysicalNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPhysicalNetworksParams) SetName(v string) {
@@ -3075,7 +2960,6 @@ func (p *ListPhysicalNetworksParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListPhysicalNetworksParams) SetPage(v int) {
@@ -3083,7 +2967,6 @@ func (p *ListPhysicalNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPhysicalNetworksParams) SetPagesize(v int) {
@@ -3091,7 +2974,6 @@ func (p *ListPhysicalNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPhysicalNetworksParams) SetZoneid(v string) {
@@ -3099,7 +2981,6 @@ func (p *ListPhysicalNetworksParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListPhysicalNetworksParams instance,
@@ -3265,7 +3146,6 @@ func (p *ListStorageNetworkIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListStorageNetworkIpRangeParams) SetKeyword(v string) {
@@ -3273,7 +3153,6 @@ func (p *ListStorageNetworkIpRangeParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListStorageNetworkIpRangeParams) SetPage(v int) {
@@ -3281,7 +3160,6 @@ func (p *ListStorageNetworkIpRangeParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListStorageNetworkIpRangeParams) SetPagesize(v int) {
@@ -3289,7 +3167,6 @@ func (p *ListStorageNetworkIpRangeParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListStorageNetworkIpRangeParams) SetPodid(v string) {
@@ -3297,7 +3174,6 @@ func (p *ListStorageNetworkIpRangeParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListStorageNetworkIpRangeParams) SetZoneid(v string) {
@@ -3305,7 +3181,6 @@ func (p *ListStorageNetworkIpRangeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListStorageNetworkIpRangeParams instance,
@@ -3417,7 +3292,6 @@ func (p *ListSupportedNetworkServicesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSupportedNetworkServicesParams) SetPage(v int) {
@@ -3425,7 +3299,6 @@ func (p *ListSupportedNetworkServicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSupportedNetworkServicesParams) SetPagesize(v int) {
@@ -3433,7 +3306,6 @@ func (p *ListSupportedNetworkServicesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSupportedNetworkServicesParams) SetProvider(v string) {
@@ -3441,7 +3313,6 @@ func (p *ListSupportedNetworkServicesParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *ListSupportedNetworkServicesParams) SetService(v string) {
@@ -3449,7 +3320,6 @@ func (p *ListSupportedNetworkServicesParams) SetService(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["service"] = v
-	return
 }
 
 // You should always use this function to get a new ListSupportedNetworkServicesParams instance,
@@ -3524,7 +3394,6 @@ func (p *ReleasePublicIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ReleasePublicIpRangeParams instance,
@@ -3613,7 +3482,6 @@ func (p *RestartNetworkParams) SetCleanup(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanup"] = v
-	return
 }
 
 func (p *RestartNetworkParams) SetId(v string) {
@@ -3621,7 +3489,6 @@ func (p *RestartNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *RestartNetworkParams) SetMakeredundant(v bool) {
@@ -3629,7 +3496,6 @@ func (p *RestartNetworkParams) SetMakeredundant(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["makeredundant"] = v
-	return
 }
 
 // You should always use this function to get a new RestartNetworkParams instance,
@@ -3765,7 +3631,6 @@ func (p *UpdateNetworkParams) SetChangecidr(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["changecidr"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetCustomid(v string) {
@@ -3773,7 +3638,6 @@ func (p *UpdateNetworkParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetDisplaynetwork(v bool) {
@@ -3781,7 +3645,6 @@ func (p *UpdateNetworkParams) SetDisplaynetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaynetwork"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetDisplaytext(v string) {
@@ -3789,7 +3652,6 @@ func (p *UpdateNetworkParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetForced(v bool) {
@@ -3797,7 +3659,6 @@ func (p *UpdateNetworkParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetGuestvmcidr(v string) {
@@ -3805,7 +3666,6 @@ func (p *UpdateNetworkParams) SetGuestvmcidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestvmcidr"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetId(v string) {
@@ -3813,7 +3673,6 @@ func (p *UpdateNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetName(v string) {
@@ -3821,7 +3680,6 @@ func (p *UpdateNetworkParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetNetworkdomain(v string) {
@@ -3829,7 +3687,6 @@ func (p *UpdateNetworkParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetNetworkofferingid(v string) {
@@ -3837,7 +3694,6 @@ func (p *UpdateNetworkParams) SetNetworkofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkofferingid"] = v
-	return
 }
 
 func (p *UpdateNetworkParams) SetUpdateinsequence(v bool) {
@@ -3845,7 +3701,6 @@ func (p *UpdateNetworkParams) SetUpdateinsequence(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["updateinsequence"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateNetworkParams instance,
@@ -3996,7 +3851,6 @@ func (p *UpdateNetworkServiceProviderParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateNetworkServiceProviderParams) SetServicelist(v []string) {
@@ -4004,7 +3858,6 @@ func (p *UpdateNetworkServiceProviderParams) SetServicelist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["servicelist"] = v
-	return
 }
 
 func (p *UpdateNetworkServiceProviderParams) SetState(v string) {
@@ -4012,7 +3865,6 @@ func (p *UpdateNetworkServiceProviderParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateNetworkServiceProviderParams instance,
@@ -4104,7 +3956,6 @@ func (p *UpdatePhysicalNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdatePhysicalNetworkParams) SetNetworkspeed(v string) {
@@ -4112,7 +3963,6 @@ func (p *UpdatePhysicalNetworkParams) SetNetworkspeed(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkspeed"] = v
-	return
 }
 
 func (p *UpdatePhysicalNetworkParams) SetState(v string) {
@@ -4120,7 +3970,6 @@ func (p *UpdatePhysicalNetworkParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *UpdatePhysicalNetworkParams) SetTags(v []string) {
@@ -4128,7 +3977,6 @@ func (p *UpdatePhysicalNetworkParams) SetTags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *UpdatePhysicalNetworkParams) SetVlan(v string) {
@@ -4136,7 +3984,6 @@ func (p *UpdatePhysicalNetworkParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 // You should always use this function to get a new UpdatePhysicalNetworkParams instance,
@@ -4231,7 +4078,6 @@ func (p *UpdateStorageNetworkIpRangeParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *UpdateStorageNetworkIpRangeParams) SetId(v string) {
@@ -4239,7 +4085,6 @@ func (p *UpdateStorageNetworkIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateStorageNetworkIpRangeParams) SetNetmask(v string) {
@@ -4247,7 +4092,6 @@ func (p *UpdateStorageNetworkIpRangeParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *UpdateStorageNetworkIpRangeParams) SetStartip(v string) {
@@ -4255,7 +4099,6 @@ func (p *UpdateStorageNetworkIpRangeParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 func (p *UpdateStorageNetworkIpRangeParams) SetVlan(v int) {
@@ -4263,7 +4106,6 @@ func (p *UpdateStorageNetworkIpRangeParams) SetVlan(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateStorageNetworkIpRangeParams instance,

--- a/cloudstack/NicService.go
+++ b/cloudstack/NicService.go
@@ -45,7 +45,6 @@ func (p *AddIpToNicParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *AddIpToNicParams) SetNicid(v string) {
@@ -53,7 +52,6 @@ func (p *AddIpToNicParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
-	return
 }
 
 // You should always use this function to get a new AddIpToNicParams instance,
@@ -155,7 +153,6 @@ func (p *ListNicsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListNicsParams) SetKeyword(v string) {
@@ -163,7 +160,6 @@ func (p *ListNicsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNicsParams) SetNetworkid(v string) {
@@ -171,7 +167,6 @@ func (p *ListNicsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListNicsParams) SetNicid(v string) {
@@ -179,7 +174,6 @@ func (p *ListNicsParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
-	return
 }
 
 func (p *ListNicsParams) SetPage(v int) {
@@ -187,7 +181,6 @@ func (p *ListNicsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNicsParams) SetPagesize(v int) {
@@ -195,7 +188,6 @@ func (p *ListNicsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNicsParams) SetVirtualmachineid(v string) {
@@ -203,7 +195,6 @@ func (p *ListNicsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNicsParams instance,
@@ -284,7 +275,6 @@ func (p *RemoveIpFromNicParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveIpFromNicParams instance,
@@ -356,7 +346,6 @@ func (p *UpdateVmNicIpParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *UpdateVmNicIpParams) SetNicid(v string) {
@@ -364,7 +353,6 @@ func (p *UpdateVmNicIpParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVmNicIpParams instance,

--- a/cloudstack/NiciraNVPService.go
+++ b/cloudstack/NiciraNVPService.go
@@ -60,7 +60,6 @@ func (p *AddNiciraNvpDeviceParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *AddNiciraNvpDeviceParams) SetL2gatewayserviceuuid(v string) {
@@ -68,7 +67,6 @@ func (p *AddNiciraNvpDeviceParams) SetL2gatewayserviceuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["l2gatewayserviceuuid"] = v
-	return
 }
 
 func (p *AddNiciraNvpDeviceParams) SetL3gatewayserviceuuid(v string) {
@@ -76,7 +74,6 @@ func (p *AddNiciraNvpDeviceParams) SetL3gatewayserviceuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["l3gatewayserviceuuid"] = v
-	return
 }
 
 func (p *AddNiciraNvpDeviceParams) SetPassword(v string) {
@@ -84,7 +81,6 @@ func (p *AddNiciraNvpDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddNiciraNvpDeviceParams) SetPhysicalnetworkid(v string) {
@@ -92,7 +88,6 @@ func (p *AddNiciraNvpDeviceParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddNiciraNvpDeviceParams) SetTransportzoneuuid(v string) {
@@ -100,7 +95,6 @@ func (p *AddNiciraNvpDeviceParams) SetTransportzoneuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["transportzoneuuid"] = v
-	return
 }
 
 func (p *AddNiciraNvpDeviceParams) SetUsername(v string) {
@@ -108,7 +102,6 @@ func (p *AddNiciraNvpDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddNiciraNvpDeviceParams instance,
@@ -192,7 +185,6 @@ func (p *DeleteNiciraNvpDeviceParams) SetNvpdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nvpdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNiciraNvpDeviceParams instance,
@@ -275,7 +267,6 @@ func (p *ListNiciraNvpDevicesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNiciraNvpDevicesParams) SetNvpdeviceid(v string) {
@@ -283,7 +274,6 @@ func (p *ListNiciraNvpDevicesParams) SetNvpdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nvpdeviceid"] = v
-	return
 }
 
 func (p *ListNiciraNvpDevicesParams) SetPage(v int) {
@@ -291,7 +281,6 @@ func (p *ListNiciraNvpDevicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNiciraNvpDevicesParams) SetPagesize(v int) {
@@ -299,7 +288,6 @@ func (p *ListNiciraNvpDevicesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNiciraNvpDevicesParams) SetPhysicalnetworkid(v string) {
@@ -307,7 +295,6 @@ func (p *ListNiciraNvpDevicesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNiciraNvpDevicesParams instance,

--- a/cloudstack/NuageVSPService.go
+++ b/cloudstack/NuageVSPService.go
@@ -66,7 +66,6 @@ func (p *AddNuageVspDeviceParams) SetApiversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["apiversion"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetHostname(v string) {
@@ -74,7 +73,6 @@ func (p *AddNuageVspDeviceParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetPassword(v string) {
@@ -82,7 +80,6 @@ func (p *AddNuageVspDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetPhysicalnetworkid(v string) {
@@ -90,7 +87,6 @@ func (p *AddNuageVspDeviceParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetPort(v int) {
@@ -98,7 +94,6 @@ func (p *AddNuageVspDeviceParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetRetrycount(v int) {
@@ -106,7 +101,6 @@ func (p *AddNuageVspDeviceParams) SetRetrycount(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retrycount"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetRetryinterval(v int64) {
@@ -114,7 +108,6 @@ func (p *AddNuageVspDeviceParams) SetRetryinterval(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retryinterval"] = v
-	return
 }
 
 func (p *AddNuageVspDeviceParams) SetUsername(v string) {
@@ -122,7 +115,6 @@ func (p *AddNuageVspDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddNuageVspDeviceParams instance,
@@ -208,7 +200,6 @@ func (p *DeleteNuageVspDeviceParams) SetVspdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vspdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteNuageVspDeviceParams instance,
@@ -291,7 +282,6 @@ func (p *ListNuageVspDevicesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListNuageVspDevicesParams) SetPage(v int) {
@@ -299,7 +289,6 @@ func (p *ListNuageVspDevicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListNuageVspDevicesParams) SetPagesize(v int) {
@@ -307,7 +296,6 @@ func (p *ListNuageVspDevicesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListNuageVspDevicesParams) SetPhysicalnetworkid(v string) {
@@ -315,7 +303,6 @@ func (p *ListNuageVspDevicesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListNuageVspDevicesParams) SetVspdeviceid(v string) {
@@ -323,7 +310,6 @@ func (p *ListNuageVspDevicesParams) SetVspdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vspdeviceid"] = v
-	return
 }
 
 // You should always use this function to get a new ListNuageVspDevicesParams instance,
@@ -413,7 +399,6 @@ func (p *UpdateNuageVspDeviceParams) SetApiversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["apiversion"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetHostname(v string) {
@@ -421,7 +406,6 @@ func (p *UpdateNuageVspDeviceParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetPassword(v string) {
@@ -429,7 +413,6 @@ func (p *UpdateNuageVspDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetPhysicalnetworkid(v string) {
@@ -437,7 +420,6 @@ func (p *UpdateNuageVspDeviceParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetPort(v int) {
@@ -445,7 +427,6 @@ func (p *UpdateNuageVspDeviceParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetRetrycount(v int) {
@@ -453,7 +434,6 @@ func (p *UpdateNuageVspDeviceParams) SetRetrycount(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retrycount"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetRetryinterval(v int64) {
@@ -461,7 +441,6 @@ func (p *UpdateNuageVspDeviceParams) SetRetryinterval(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retryinterval"] = v
-	return
 }
 
 func (p *UpdateNuageVspDeviceParams) SetUsername(v string) {
@@ -469,7 +448,6 @@ func (p *UpdateNuageVspDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateNuageVspDeviceParams instance,

--- a/cloudstack/OutofbandManagementService.go
+++ b/cloudstack/OutofbandManagementService.go
@@ -45,7 +45,6 @@ func (p *ChangeOutOfBandManagementPasswordParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ChangeOutOfBandManagementPasswordParams) SetPassword(v string) {
@@ -53,7 +52,6 @@ func (p *ChangeOutOfBandManagementPasswordParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 // You should always use this function to get a new ChangeOutOfBandManagementPasswordParams instance,
@@ -151,7 +149,6 @@ func (p *ConfigureOutOfBandManagementParams) SetAddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["address"] = v
-	return
 }
 
 func (p *ConfigureOutOfBandManagementParams) SetDriver(v string) {
@@ -159,7 +156,6 @@ func (p *ConfigureOutOfBandManagementParams) SetDriver(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["driver"] = v
-	return
 }
 
 func (p *ConfigureOutOfBandManagementParams) SetHostid(v string) {
@@ -167,7 +163,6 @@ func (p *ConfigureOutOfBandManagementParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ConfigureOutOfBandManagementParams) SetPassword(v string) {
@@ -175,7 +170,6 @@ func (p *ConfigureOutOfBandManagementParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *ConfigureOutOfBandManagementParams) SetPort(v string) {
@@ -183,7 +177,6 @@ func (p *ConfigureOutOfBandManagementParams) SetPort(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
-	return
 }
 
 func (p *ConfigureOutOfBandManagementParams) SetUsername(v string) {
@@ -191,7 +184,6 @@ func (p *ConfigureOutOfBandManagementParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new ConfigureOutOfBandManagementParams instance,
@@ -266,7 +258,6 @@ func (p *IssueOutOfBandManagementPowerActionParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
-	return
 }
 
 func (p *IssueOutOfBandManagementPowerActionParams) SetHostid(v string) {
@@ -274,7 +265,6 @@ func (p *IssueOutOfBandManagementPowerActionParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *IssueOutOfBandManagementPowerActionParams) SetTimeout(v int64) {
@@ -282,7 +272,6 @@ func (p *IssueOutOfBandManagementPowerActionParams) SetTimeout(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timeout"] = v
-	return
 }
 
 // You should always use this function to get a new IssueOutOfBandManagementPowerActionParams instance,

--- a/cloudstack/OvsElementService.go
+++ b/cloudstack/OvsElementService.go
@@ -48,7 +48,6 @@ func (p *ConfigureOvsElementParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *ConfigureOvsElementParams) SetId(v string) {
@@ -56,7 +55,6 @@ func (p *ConfigureOvsElementParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ConfigureOvsElementParams instance,
@@ -155,7 +153,6 @@ func (p *ListOvsElementsParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *ListOvsElementsParams) SetId(v string) {
@@ -163,7 +160,6 @@ func (p *ListOvsElementsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListOvsElementsParams) SetKeyword(v string) {
@@ -171,7 +167,6 @@ func (p *ListOvsElementsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListOvsElementsParams) SetNspid(v string) {
@@ -179,7 +174,6 @@ func (p *ListOvsElementsParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
-	return
 }
 
 func (p *ListOvsElementsParams) SetPage(v int) {
@@ -187,7 +181,6 @@ func (p *ListOvsElementsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListOvsElementsParams) SetPagesize(v int) {
@@ -195,7 +188,6 @@ func (p *ListOvsElementsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListOvsElementsParams instance,

--- a/cloudstack/PodService.go
+++ b/cloudstack/PodService.go
@@ -62,7 +62,6 @@ func (p *CreatePodParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *CreatePodParams) SetEndip(v string) {
@@ -70,7 +69,6 @@ func (p *CreatePodParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *CreatePodParams) SetGateway(v string) {
@@ -78,7 +76,6 @@ func (p *CreatePodParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreatePodParams) SetName(v string) {
@@ -86,7 +83,6 @@ func (p *CreatePodParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreatePodParams) SetNetmask(v string) {
@@ -94,7 +90,6 @@ func (p *CreatePodParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *CreatePodParams) SetStartip(v string) {
@@ -102,7 +97,6 @@ func (p *CreatePodParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 func (p *CreatePodParams) SetZoneid(v string) {
@@ -110,7 +104,6 @@ func (p *CreatePodParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreatePodParams instance,
@@ -199,7 +192,6 @@ func (p *DedicatePodParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DedicatePodParams) SetDomainid(v string) {
@@ -207,7 +199,6 @@ func (p *DedicatePodParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DedicatePodParams) SetPodid(v string) {
@@ -215,7 +206,6 @@ func (p *DedicatePodParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 // You should always use this function to get a new DedicatePodParams instance,
@@ -294,7 +284,6 @@ func (p *DeletePodParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeletePodParams instance,
@@ -395,7 +384,6 @@ func (p *ListDedicatedPodsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListDedicatedPodsParams) SetAffinitygroupid(v string) {
@@ -403,7 +391,6 @@ func (p *ListDedicatedPodsParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
-	return
 }
 
 func (p *ListDedicatedPodsParams) SetDomainid(v string) {
@@ -411,7 +398,6 @@ func (p *ListDedicatedPodsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListDedicatedPodsParams) SetKeyword(v string) {
@@ -419,7 +405,6 @@ func (p *ListDedicatedPodsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDedicatedPodsParams) SetPage(v int) {
@@ -427,7 +412,6 @@ func (p *ListDedicatedPodsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDedicatedPodsParams) SetPagesize(v int) {
@@ -435,7 +419,6 @@ func (p *ListDedicatedPodsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListDedicatedPodsParams) SetPodid(v string) {
@@ -443,7 +426,6 @@ func (p *ListDedicatedPodsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 // You should always use this function to get a new ListDedicatedPodsParams instance,
@@ -529,7 +511,6 @@ func (p *ListPodsParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *ListPodsParams) SetId(v string) {
@@ -537,7 +518,6 @@ func (p *ListPodsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListPodsParams) SetKeyword(v string) {
@@ -545,7 +525,6 @@ func (p *ListPodsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPodsParams) SetName(v string) {
@@ -553,7 +532,6 @@ func (p *ListPodsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListPodsParams) SetPage(v int) {
@@ -561,7 +539,6 @@ func (p *ListPodsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPodsParams) SetPagesize(v int) {
@@ -569,7 +546,6 @@ func (p *ListPodsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPodsParams) SetShowcapacities(v bool) {
@@ -577,7 +553,6 @@ func (p *ListPodsParams) SetShowcapacities(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showcapacities"] = v
-	return
 }
 
 func (p *ListPodsParams) SetZoneid(v string) {
@@ -585,7 +560,6 @@ func (p *ListPodsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListPodsParams instance,
@@ -751,7 +725,6 @@ func (p *ReleaseDedicatedPodParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 // You should always use this function to get a new ReleaseDedicatedPodParams instance,
@@ -838,7 +811,6 @@ func (p *UpdatePodParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *UpdatePodParams) SetEndip(v string) {
@@ -846,7 +818,6 @@ func (p *UpdatePodParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *UpdatePodParams) SetGateway(v string) {
@@ -854,7 +825,6 @@ func (p *UpdatePodParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *UpdatePodParams) SetId(v string) {
@@ -862,7 +832,6 @@ func (p *UpdatePodParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdatePodParams) SetName(v string) {
@@ -870,7 +839,6 @@ func (p *UpdatePodParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdatePodParams) SetNetmask(v string) {
@@ -878,7 +846,6 @@ func (p *UpdatePodParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *UpdatePodParams) SetStartip(v string) {
@@ -886,7 +853,6 @@ func (p *UpdatePodParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 // You should always use this function to get a new UpdatePodParams instance,

--- a/cloudstack/PoolService.go
+++ b/cloudstack/PoolService.go
@@ -86,7 +86,6 @@ func (p *CreateStoragePoolParams) SetCapacitybytes(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["capacitybytes"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetCapacityiops(v int64) {
@@ -94,7 +93,6 @@ func (p *CreateStoragePoolParams) SetCapacityiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["capacityiops"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetClusterid(v string) {
@@ -102,7 +100,6 @@ func (p *CreateStoragePoolParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetDetails(v map[string]string) {
@@ -110,7 +107,6 @@ func (p *CreateStoragePoolParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetHypervisor(v string) {
@@ -118,7 +114,6 @@ func (p *CreateStoragePoolParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetManaged(v bool) {
@@ -126,7 +121,6 @@ func (p *CreateStoragePoolParams) SetManaged(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managed"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetName(v string) {
@@ -134,7 +128,6 @@ func (p *CreateStoragePoolParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetPodid(v string) {
@@ -142,7 +135,6 @@ func (p *CreateStoragePoolParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetProvider(v string) {
@@ -150,7 +142,6 @@ func (p *CreateStoragePoolParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetScope(v string) {
@@ -158,7 +149,6 @@ func (p *CreateStoragePoolParams) SetScope(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scope"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetTags(v string) {
@@ -166,7 +156,6 @@ func (p *CreateStoragePoolParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetUrl(v string) {
@@ -174,7 +163,6 @@ func (p *CreateStoragePoolParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *CreateStoragePoolParams) SetZoneid(v string) {
@@ -182,7 +170,6 @@ func (p *CreateStoragePoolParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateStoragePoolParams instance,
@@ -265,7 +252,6 @@ func (p *DeleteStoragePoolParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *DeleteStoragePoolParams) SetId(v string) {
@@ -273,7 +259,6 @@ func (p *DeleteStoragePoolParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteStoragePoolParams instance,
@@ -365,7 +350,6 @@ func (p *FindStoragePoolsForMigrationParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *FindStoragePoolsForMigrationParams) SetKeyword(v string) {
@@ -373,7 +357,6 @@ func (p *FindStoragePoolsForMigrationParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *FindStoragePoolsForMigrationParams) SetPage(v int) {
@@ -381,7 +364,6 @@ func (p *FindStoragePoolsForMigrationParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *FindStoragePoolsForMigrationParams) SetPagesize(v int) {
@@ -389,7 +371,6 @@ func (p *FindStoragePoolsForMigrationParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new FindStoragePoolsForMigrationParams instance,
@@ -498,7 +479,6 @@ func (p *ListStoragePoolsParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetId(v string) {
@@ -506,7 +486,6 @@ func (p *ListStoragePoolsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetIpaddress(v string) {
@@ -514,7 +493,6 @@ func (p *ListStoragePoolsParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetKeyword(v string) {
@@ -522,7 +500,6 @@ func (p *ListStoragePoolsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetName(v string) {
@@ -530,7 +507,6 @@ func (p *ListStoragePoolsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetPage(v int) {
@@ -538,7 +514,6 @@ func (p *ListStoragePoolsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetPagesize(v int) {
@@ -546,7 +521,6 @@ func (p *ListStoragePoolsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetPath(v string) {
@@ -554,7 +528,6 @@ func (p *ListStoragePoolsParams) SetPath(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["path"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetPodid(v string) {
@@ -562,7 +535,6 @@ func (p *ListStoragePoolsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetScope(v string) {
@@ -570,7 +542,6 @@ func (p *ListStoragePoolsParams) SetScope(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scope"] = v
-	return
 }
 
 func (p *ListStoragePoolsParams) SetZoneid(v string) {
@@ -578,7 +549,6 @@ func (p *ListStoragePoolsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListStoragePoolsParams instance,
@@ -758,7 +728,6 @@ func (p *UpdateStoragePoolParams) SetCapacitybytes(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["capacitybytes"] = v
-	return
 }
 
 func (p *UpdateStoragePoolParams) SetCapacityiops(v int64) {
@@ -766,7 +735,6 @@ func (p *UpdateStoragePoolParams) SetCapacityiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["capacityiops"] = v
-	return
 }
 
 func (p *UpdateStoragePoolParams) SetEnabled(v bool) {
@@ -774,7 +742,6 @@ func (p *UpdateStoragePoolParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *UpdateStoragePoolParams) SetId(v string) {
@@ -782,7 +749,6 @@ func (p *UpdateStoragePoolParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateStoragePoolParams) SetTags(v []string) {
@@ -790,7 +756,6 @@ func (p *UpdateStoragePoolParams) SetTags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateStoragePoolParams instance,

--- a/cloudstack/PortableIPService.go
+++ b/cloudstack/PortableIPService.go
@@ -60,7 +60,6 @@ func (p *CreatePortableIpRangeParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *CreatePortableIpRangeParams) SetGateway(v string) {
@@ -68,7 +67,6 @@ func (p *CreatePortableIpRangeParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreatePortableIpRangeParams) SetNetmask(v string) {
@@ -76,7 +74,6 @@ func (p *CreatePortableIpRangeParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *CreatePortableIpRangeParams) SetRegionid(v int) {
@@ -84,7 +81,6 @@ func (p *CreatePortableIpRangeParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
-	return
 }
 
 func (p *CreatePortableIpRangeParams) SetStartip(v string) {
@@ -92,7 +88,6 @@ func (p *CreatePortableIpRangeParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 func (p *CreatePortableIpRangeParams) SetVlan(v string) {
@@ -100,7 +95,6 @@ func (p *CreatePortableIpRangeParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 // You should always use this function to get a new CreatePortableIpRangeParams instance,
@@ -197,7 +191,6 @@ func (p *DeletePortableIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeletePortableIpRangeParams instance,
@@ -281,7 +274,6 @@ func (p *ListPortableIpRangesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListPortableIpRangesParams) SetKeyword(v string) {
@@ -289,7 +281,6 @@ func (p *ListPortableIpRangesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPortableIpRangesParams) SetPage(v int) {
@@ -297,7 +288,6 @@ func (p *ListPortableIpRangesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPortableIpRangesParams) SetPagesize(v int) {
@@ -305,7 +295,6 @@ func (p *ListPortableIpRangesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPortableIpRangesParams) SetRegionid(v int) {
@@ -313,7 +302,6 @@ func (p *ListPortableIpRangesParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
-	return
 }
 
 // You should always use this function to get a new ListPortableIpRangesParams instance,

--- a/cloudstack/ProjectService.go
+++ b/cloudstack/ProjectService.go
@@ -44,7 +44,6 @@ func (p *ActivateProjectParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ActivateProjectParams instance,
@@ -169,7 +168,6 @@ func (p *CreateProjectParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateProjectParams) SetDisplaytext(v string) {
@@ -177,7 +175,6 @@ func (p *CreateProjectParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateProjectParams) SetDomainid(v string) {
@@ -185,7 +182,6 @@ func (p *CreateProjectParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateProjectParams) SetName(v string) {
@@ -193,7 +189,6 @@ func (p *CreateProjectParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new CreateProjectParams instance,
@@ -310,7 +305,6 @@ func (p *DeleteProjectParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteProjectParams instance,
@@ -379,7 +373,6 @@ func (p *DeleteProjectInvitationParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteProjectInvitationParams instance,
@@ -483,7 +476,6 @@ func (p *ListProjectInvitationsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetActiveonly(v bool) {
@@ -491,7 +483,6 @@ func (p *ListProjectInvitationsParams) SetActiveonly(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["activeonly"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetDomainid(v string) {
@@ -499,7 +490,6 @@ func (p *ListProjectInvitationsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetId(v string) {
@@ -507,7 +497,6 @@ func (p *ListProjectInvitationsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetIsrecursive(v bool) {
@@ -515,7 +504,6 @@ func (p *ListProjectInvitationsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetKeyword(v string) {
@@ -523,7 +511,6 @@ func (p *ListProjectInvitationsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetListall(v bool) {
@@ -531,7 +518,6 @@ func (p *ListProjectInvitationsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetPage(v int) {
@@ -539,7 +525,6 @@ func (p *ListProjectInvitationsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetPagesize(v int) {
@@ -547,7 +532,6 @@ func (p *ListProjectInvitationsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetProjectid(v string) {
@@ -555,7 +539,6 @@ func (p *ListProjectInvitationsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListProjectInvitationsParams) SetState(v string) {
@@ -563,7 +546,6 @@ func (p *ListProjectInvitationsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 // You should always use this function to get a new ListProjectInvitationsParams instance,
@@ -701,7 +683,6 @@ func (p *ListProjectsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetDisplaytext(v string) {
@@ -709,7 +690,6 @@ func (p *ListProjectsParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetDomainid(v string) {
@@ -717,7 +697,6 @@ func (p *ListProjectsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetId(v string) {
@@ -725,7 +704,6 @@ func (p *ListProjectsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetIsrecursive(v bool) {
@@ -733,7 +711,6 @@ func (p *ListProjectsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetKeyword(v string) {
@@ -741,7 +718,6 @@ func (p *ListProjectsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetListall(v bool) {
@@ -749,7 +725,6 @@ func (p *ListProjectsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetName(v string) {
@@ -757,7 +732,6 @@ func (p *ListProjectsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetPage(v int) {
@@ -765,7 +739,6 @@ func (p *ListProjectsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetPagesize(v int) {
@@ -773,7 +746,6 @@ func (p *ListProjectsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetState(v string) {
@@ -781,7 +753,6 @@ func (p *ListProjectsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListProjectsParams) SetTags(v map[string]string) {
@@ -789,7 +760,6 @@ func (p *ListProjectsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListProjectsParams instance,
@@ -972,7 +942,6 @@ func (p *SuspendProjectParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new SuspendProjectParams instance,
@@ -1094,7 +1063,6 @@ func (p *UpdateProjectParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpdateProjectParams) SetDisplaytext(v string) {
@@ -1102,7 +1070,6 @@ func (p *UpdateProjectParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateProjectParams) SetId(v string) {
@@ -1110,7 +1077,6 @@ func (p *UpdateProjectParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateProjectParams instance,
@@ -1236,7 +1202,6 @@ func (p *UpdateProjectInvitationParams) SetAccept(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accept"] = v
-	return
 }
 
 func (p *UpdateProjectInvitationParams) SetAccount(v string) {
@@ -1244,7 +1209,6 @@ func (p *UpdateProjectInvitationParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpdateProjectInvitationParams) SetProjectid(v string) {
@@ -1252,7 +1216,6 @@ func (p *UpdateProjectInvitationParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *UpdateProjectInvitationParams) SetToken(v string) {
@@ -1260,7 +1223,6 @@ func (p *UpdateProjectInvitationParams) SetToken(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["token"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateProjectInvitationParams instance,

--- a/cloudstack/RegionService.go
+++ b/cloudstack/RegionService.go
@@ -49,7 +49,6 @@ func (p *AddRegionParams) SetEndpoint(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endpoint"] = v
-	return
 }
 
 func (p *AddRegionParams) SetId(v int) {
@@ -57,7 +56,6 @@ func (p *AddRegionParams) SetId(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *AddRegionParams) SetName(v string) {
@@ -65,7 +63,6 @@ func (p *AddRegionParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new AddRegionParams instance,
@@ -139,7 +136,6 @@ func (p *ListRegionsParams) SetId(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListRegionsParams) SetKeyword(v string) {
@@ -147,7 +143,6 @@ func (p *ListRegionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListRegionsParams) SetName(v string) {
@@ -155,7 +150,6 @@ func (p *ListRegionsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListRegionsParams) SetPage(v int) {
@@ -163,7 +157,6 @@ func (p *ListRegionsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListRegionsParams) SetPagesize(v int) {
@@ -171,7 +164,6 @@ func (p *ListRegionsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListRegionsParams instance,
@@ -233,7 +225,6 @@ func (p *RemoveRegionParams) SetId(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveRegionParams instance,
@@ -321,7 +312,6 @@ func (p *UpdateRegionParams) SetEndpoint(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endpoint"] = v
-	return
 }
 
 func (p *UpdateRegionParams) SetId(v int) {
@@ -329,7 +319,6 @@ func (p *UpdateRegionParams) SetId(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateRegionParams) SetName(v string) {
@@ -337,7 +326,6 @@ func (p *UpdateRegionParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateRegionParams instance,

--- a/cloudstack/ResourcemetadataService.go
+++ b/cloudstack/ResourcemetadataService.go
@@ -57,7 +57,6 @@ func (p *AddResourceDetailParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *AddResourceDetailParams) SetFordisplay(v bool) {
@@ -65,7 +64,6 @@ func (p *AddResourceDetailParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *AddResourceDetailParams) SetResourceid(v string) {
@@ -73,7 +71,6 @@ func (p *AddResourceDetailParams) SetResourceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceid"] = v
-	return
 }
 
 func (p *AddResourceDetailParams) SetResourcetype(v string) {
@@ -81,7 +78,6 @@ func (p *AddResourceDetailParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 // You should always use this function to get a new AddResourceDetailParams instance,
@@ -152,7 +148,6 @@ func (p *GetVolumeSnapshotDetailsParams) SetSnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshotid"] = v
-	return
 }
 
 // You should always use this function to get a new GetVolumeSnapshotDetailsParams instance,
@@ -246,7 +241,6 @@ func (p *ListResourceDetailsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetDomainid(v string) {
@@ -254,7 +248,6 @@ func (p *ListResourceDetailsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetFordisplay(v bool) {
@@ -262,7 +255,6 @@ func (p *ListResourceDetailsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetIsrecursive(v bool) {
@@ -270,7 +262,6 @@ func (p *ListResourceDetailsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetKey(v string) {
@@ -278,7 +269,6 @@ func (p *ListResourceDetailsParams) SetKey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["key"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetKeyword(v string) {
@@ -286,7 +276,6 @@ func (p *ListResourceDetailsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetListall(v bool) {
@@ -294,7 +283,6 @@ func (p *ListResourceDetailsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetPage(v int) {
@@ -302,7 +290,6 @@ func (p *ListResourceDetailsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetPagesize(v int) {
@@ -310,7 +297,6 @@ func (p *ListResourceDetailsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetProjectid(v string) {
@@ -318,7 +304,6 @@ func (p *ListResourceDetailsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetResourceid(v string) {
@@ -326,7 +311,6 @@ func (p *ListResourceDetailsParams) SetResourceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceid"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetResourcetype(v string) {
@@ -334,7 +318,6 @@ func (p *ListResourceDetailsParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 func (p *ListResourceDetailsParams) SetValue(v string) {
@@ -342,7 +325,6 @@ func (p *ListResourceDetailsParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
-	return
 }
 
 // You should always use this function to get a new ListResourceDetailsParams instance,
@@ -415,7 +397,6 @@ func (p *RemoveResourceDetailParams) SetKey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["key"] = v
-	return
 }
 
 func (p *RemoveResourceDetailParams) SetResourceid(v string) {
@@ -423,7 +404,6 @@ func (p *RemoveResourceDetailParams) SetResourceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceid"] = v
-	return
 }
 
 func (p *RemoveResourceDetailParams) SetResourcetype(v string) {
@@ -431,7 +411,6 @@ func (p *RemoveResourceDetailParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveResourceDetailParams instance,

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -58,7 +58,6 @@ func (p *CreateTagsParams) SetCustomer(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customer"] = v
-	return
 }
 
 func (p *CreateTagsParams) SetResourceids(v []string) {
@@ -66,7 +65,6 @@ func (p *CreateTagsParams) SetResourceids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceids"] = v
-	return
 }
 
 func (p *CreateTagsParams) SetResourcetype(v string) {
@@ -74,7 +72,6 @@ func (p *CreateTagsParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 func (p *CreateTagsParams) SetTags(v map[string]string) {
@@ -82,7 +79,6 @@ func (p *CreateTagsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new CreateTagsParams instance,
@@ -164,7 +160,6 @@ func (p *DeleteTagsParams) SetResourceids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceids"] = v
-	return
 }
 
 func (p *DeleteTagsParams) SetResourcetype(v string) {
@@ -172,7 +167,6 @@ func (p *DeleteTagsParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 func (p *DeleteTagsParams) SetTags(v map[string]string) {
@@ -180,7 +174,6 @@ func (p *DeleteTagsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteTagsParams instance,
@@ -258,7 +251,6 @@ func (p *ListStorageTagsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListStorageTagsParams) SetPage(v int) {
@@ -266,7 +258,6 @@ func (p *ListStorageTagsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListStorageTagsParams) SetPagesize(v int) {
@@ -274,7 +265,6 @@ func (p *ListStorageTagsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListStorageTagsParams instance,
@@ -409,7 +399,6 @@ func (p *ListTagsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListTagsParams) SetCustomer(v string) {
@@ -417,7 +406,6 @@ func (p *ListTagsParams) SetCustomer(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customer"] = v
-	return
 }
 
 func (p *ListTagsParams) SetDomainid(v string) {
@@ -425,7 +413,6 @@ func (p *ListTagsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListTagsParams) SetIsrecursive(v bool) {
@@ -433,7 +420,6 @@ func (p *ListTagsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListTagsParams) SetKey(v string) {
@@ -441,7 +427,6 @@ func (p *ListTagsParams) SetKey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["key"] = v
-	return
 }
 
 func (p *ListTagsParams) SetKeyword(v string) {
@@ -449,7 +434,6 @@ func (p *ListTagsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListTagsParams) SetListall(v bool) {
@@ -457,7 +441,6 @@ func (p *ListTagsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListTagsParams) SetPage(v int) {
@@ -465,7 +448,6 @@ func (p *ListTagsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListTagsParams) SetPagesize(v int) {
@@ -473,7 +455,6 @@ func (p *ListTagsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListTagsParams) SetProjectid(v string) {
@@ -481,7 +462,6 @@ func (p *ListTagsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListTagsParams) SetResourceid(v string) {
@@ -489,7 +469,6 @@ func (p *ListTagsParams) SetResourceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceid"] = v
-	return
 }
 
 func (p *ListTagsParams) SetResourcetype(v string) {
@@ -497,7 +476,6 @@ func (p *ListTagsParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
-	return
 }
 
 func (p *ListTagsParams) SetValue(v string) {
@@ -505,7 +483,6 @@ func (p *ListTagsParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
-	return
 }
 
 // You should always use this function to get a new ListTagsParams instance,

--- a/cloudstack/RoleService.go
+++ b/cloudstack/RoleService.go
@@ -50,7 +50,6 @@ func (p *CreateRoleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateRoleParams) SetName(v string) {
@@ -58,7 +57,6 @@ func (p *CreateRoleParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateRoleParams) SetType(v string) {
@@ -66,7 +64,6 @@ func (p *CreateRoleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new CreateRoleParams instance,
@@ -132,7 +129,6 @@ func (p *CreateRolePermissionParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateRolePermissionParams) SetPermission(v string) {
@@ -140,7 +136,6 @@ func (p *CreateRolePermissionParams) SetPermission(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["permission"] = v
-	return
 }
 
 func (p *CreateRolePermissionParams) SetRoleid(v string) {
@@ -148,7 +143,6 @@ func (p *CreateRolePermissionParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 func (p *CreateRolePermissionParams) SetRule(v string) {
@@ -156,7 +150,6 @@ func (p *CreateRolePermissionParams) SetRule(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["rule"] = v
-	return
 }
 
 // You should always use this function to get a new CreateRolePermissionParams instance,
@@ -216,7 +209,6 @@ func (p *DeleteRoleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteRoleParams instance,
@@ -297,7 +289,6 @@ func (p *DeleteRolePermissionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteRolePermissionParams instance,
@@ -378,7 +369,6 @@ func (p *ListRolePermissionsParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 // You should always use this function to get a new ListRolePermissionsParams instance,
@@ -446,7 +436,6 @@ func (p *ListRolesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListRolesParams) SetName(v string) {
@@ -454,7 +443,6 @@ func (p *ListRolesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListRolesParams) SetType(v string) {
@@ -462,7 +450,6 @@ func (p *ListRolesParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new ListRolesParams instance,
@@ -614,7 +601,6 @@ func (p *UpdateRoleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *UpdateRoleParams) SetId(v string) {
@@ -622,7 +608,6 @@ func (p *UpdateRoleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateRoleParams) SetName(v string) {
@@ -630,7 +615,6 @@ func (p *UpdateRoleParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateRoleParams) SetType(v string) {
@@ -638,7 +622,6 @@ func (p *UpdateRoleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateRoleParams instance,
@@ -704,7 +687,6 @@ func (p *UpdateRolePermissionParams) SetPermission(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["permission"] = v
-	return
 }
 
 func (p *UpdateRolePermissionParams) SetRoleid(v string) {
@@ -712,7 +694,6 @@ func (p *UpdateRolePermissionParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
-	return
 }
 
 func (p *UpdateRolePermissionParams) SetRuleid(v string) {
@@ -720,7 +701,6 @@ func (p *UpdateRolePermissionParams) SetRuleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ruleid"] = v
-	return
 }
 
 func (p *UpdateRolePermissionParams) SetRuleorder(v []string) {
@@ -728,7 +708,6 @@ func (p *UpdateRolePermissionParams) SetRuleorder(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ruleorder"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateRolePermissionParams instance,

--- a/cloudstack/RouterService.go
+++ b/cloudstack/RouterService.go
@@ -47,7 +47,6 @@ func (p *ChangeServiceForRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ChangeServiceForRouterParams) SetServiceofferingid(v string) {
@@ -55,7 +54,6 @@ func (p *ChangeServiceForRouterParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 // You should always use this function to get a new ChangeServiceForRouterParams instance,
@@ -158,7 +156,6 @@ func (p *ConfigureVirtualRouterElementParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *ConfigureVirtualRouterElementParams) SetId(v string) {
@@ -166,7 +163,6 @@ func (p *ConfigureVirtualRouterElementParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ConfigureVirtualRouterElementParams instance,
@@ -250,7 +246,6 @@ func (p *CreateVirtualRouterElementParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
-	return
 }
 
 func (p *CreateVirtualRouterElementParams) SetProvidertype(v string) {
@@ -258,7 +253,6 @@ func (p *CreateVirtualRouterElementParams) SetProvidertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["providertype"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVirtualRouterElementParams instance,
@@ -338,7 +332,6 @@ func (p *DestroyRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DestroyRouterParams instance,
@@ -515,7 +508,6 @@ func (p *ListRoutersParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetClusterid(v string) {
@@ -523,7 +515,6 @@ func (p *ListRoutersParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetDomainid(v string) {
@@ -531,7 +522,6 @@ func (p *ListRoutersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetForvpc(v bool) {
@@ -539,7 +529,6 @@ func (p *ListRoutersParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetHostid(v string) {
@@ -547,7 +536,6 @@ func (p *ListRoutersParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetId(v string) {
@@ -555,7 +543,6 @@ func (p *ListRoutersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetIsrecursive(v bool) {
@@ -563,7 +550,6 @@ func (p *ListRoutersParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetKeyword(v string) {
@@ -571,7 +557,6 @@ func (p *ListRoutersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetListall(v bool) {
@@ -579,7 +564,6 @@ func (p *ListRoutersParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetName(v string) {
@@ -587,7 +571,6 @@ func (p *ListRoutersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetNetworkid(v string) {
@@ -595,7 +578,6 @@ func (p *ListRoutersParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetPage(v int) {
@@ -603,7 +585,6 @@ func (p *ListRoutersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetPagesize(v int) {
@@ -611,7 +592,6 @@ func (p *ListRoutersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetPodid(v string) {
@@ -619,7 +599,6 @@ func (p *ListRoutersParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetProjectid(v string) {
@@ -627,7 +606,6 @@ func (p *ListRoutersParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetState(v string) {
@@ -635,7 +613,6 @@ func (p *ListRoutersParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetVersion(v string) {
@@ -643,7 +620,6 @@ func (p *ListRoutersParams) SetVersion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["version"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetVpcid(v string) {
@@ -651,7 +627,6 @@ func (p *ListRoutersParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *ListRoutersParams) SetZoneid(v string) {
@@ -659,7 +634,6 @@ func (p *ListRoutersParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListRoutersParams instance,
@@ -862,7 +836,6 @@ func (p *ListVirtualRouterElementsParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
-	return
 }
 
 func (p *ListVirtualRouterElementsParams) SetId(v string) {
@@ -870,7 +843,6 @@ func (p *ListVirtualRouterElementsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVirtualRouterElementsParams) SetKeyword(v string) {
@@ -878,7 +850,6 @@ func (p *ListVirtualRouterElementsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVirtualRouterElementsParams) SetNspid(v string) {
@@ -886,7 +857,6 @@ func (p *ListVirtualRouterElementsParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
-	return
 }
 
 func (p *ListVirtualRouterElementsParams) SetPage(v int) {
@@ -894,7 +864,6 @@ func (p *ListVirtualRouterElementsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVirtualRouterElementsParams) SetPagesize(v int) {
@@ -902,7 +871,6 @@ func (p *ListVirtualRouterElementsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListVirtualRouterElementsParams instance,
@@ -999,7 +967,6 @@ func (p *RebootRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RebootRouterParams instance,
@@ -1117,7 +1084,6 @@ func (p *StartRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StartRouterParams instance,
@@ -1239,7 +1205,6 @@ func (p *StopRouterParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *StopRouterParams) SetId(v string) {
@@ -1247,7 +1212,6 @@ func (p *StopRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StopRouterParams instance,

--- a/cloudstack/SSHService.go
+++ b/cloudstack/SSHService.go
@@ -51,7 +51,6 @@ func (p *CreateSSHKeyPairParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateSSHKeyPairParams) SetDomainid(v string) {
@@ -59,7 +58,6 @@ func (p *CreateSSHKeyPairParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateSSHKeyPairParams) SetName(v string) {
@@ -67,7 +65,6 @@ func (p *CreateSSHKeyPairParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateSSHKeyPairParams) SetProjectid(v string) {
@@ -75,7 +72,6 @@ func (p *CreateSSHKeyPairParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateSSHKeyPairParams instance,
@@ -146,7 +142,6 @@ func (p *DeleteSSHKeyPairParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DeleteSSHKeyPairParams) SetDomainid(v string) {
@@ -154,7 +149,6 @@ func (p *DeleteSSHKeyPairParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DeleteSSHKeyPairParams) SetName(v string) {
@@ -162,7 +156,6 @@ func (p *DeleteSSHKeyPairParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *DeleteSSHKeyPairParams) SetProjectid(v string) {
@@ -170,7 +163,6 @@ func (p *DeleteSSHKeyPairParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteSSHKeyPairParams instance,
@@ -282,7 +274,6 @@ func (p *ListSSHKeyPairsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetDomainid(v string) {
@@ -290,7 +281,6 @@ func (p *ListSSHKeyPairsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetFingerprint(v string) {
@@ -298,7 +288,6 @@ func (p *ListSSHKeyPairsParams) SetFingerprint(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fingerprint"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetIsrecursive(v bool) {
@@ -306,7 +295,6 @@ func (p *ListSSHKeyPairsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetKeyword(v string) {
@@ -314,7 +302,6 @@ func (p *ListSSHKeyPairsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetListall(v bool) {
@@ -322,7 +309,6 @@ func (p *ListSSHKeyPairsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetName(v string) {
@@ -330,7 +316,6 @@ func (p *ListSSHKeyPairsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetPage(v int) {
@@ -338,7 +323,6 @@ func (p *ListSSHKeyPairsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetPagesize(v int) {
@@ -346,7 +330,6 @@ func (p *ListSSHKeyPairsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSSHKeyPairsParams) SetProjectid(v string) {
@@ -354,7 +337,6 @@ func (p *ListSSHKeyPairsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSSHKeyPairsParams instance,
@@ -427,7 +409,6 @@ func (p *RegisterSSHKeyPairParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *RegisterSSHKeyPairParams) SetDomainid(v string) {
@@ -435,7 +416,6 @@ func (p *RegisterSSHKeyPairParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *RegisterSSHKeyPairParams) SetName(v string) {
@@ -443,7 +423,6 @@ func (p *RegisterSSHKeyPairParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *RegisterSSHKeyPairParams) SetProjectid(v string) {
@@ -451,7 +430,6 @@ func (p *RegisterSSHKeyPairParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *RegisterSSHKeyPairParams) SetPublickey(v string) {
@@ -459,7 +437,6 @@ func (p *RegisterSSHKeyPairParams) SetPublickey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publickey"] = v
-	return
 }
 
 // You should always use this function to get a new RegisterSSHKeyPairParams instance,
@@ -533,7 +510,6 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) SetDomainid(v string) {
@@ -541,7 +517,6 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) SetId(v string) {
@@ -549,7 +524,6 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) SetKeypair(v string) {
@@ -557,7 +531,6 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
-	return
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) SetProjectid(v string) {
@@ -565,7 +538,6 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new ResetSSHKeyForVirtualMachineParams instance,

--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -118,7 +118,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetCidrlist(v []string) {
@@ -126,7 +125,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetDomainid(v string) {
@@ -134,7 +132,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetEndport(v int) {
@@ -142,7 +139,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetIcmpcode(v int) {
@@ -150,7 +146,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetIcmptype(v int) {
@@ -158,7 +153,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetProjectid(v string) {
@@ -166,7 +160,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetProtocol(v string) {
@@ -174,7 +167,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupid(v string) {
@@ -182,7 +174,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupid"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupname(v string) {
@@ -190,7 +181,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupname"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetStartport(v int) {
@@ -198,7 +188,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) SetUsersecuritygrouplist(v map[string]string) {
@@ -206,7 +195,6 @@ func (p *AuthorizeSecurityGroupEgressParams) SetUsersecuritygrouplist(v map[stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["usersecuritygrouplist"] = v
-	return
 }
 
 // You should always use this function to get a new AuthorizeSecurityGroupEgressParams instance,
@@ -334,7 +322,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetCidrlist(v []string) {
@@ -342,7 +329,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetDomainid(v string) {
@@ -350,7 +336,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetEndport(v int) {
@@ -358,7 +343,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetIcmpcode(v int) {
@@ -366,7 +350,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetIcmptype(v int) {
@@ -374,7 +357,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetProjectid(v string) {
@@ -382,7 +364,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetProtocol(v string) {
@@ -390,7 +371,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupid(v string) {
@@ -398,7 +378,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupid"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupname(v string) {
@@ -406,7 +385,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupname"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetStartport(v int) {
@@ -414,7 +392,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
-	return
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) SetUsersecuritygrouplist(v map[string]string) {
@@ -422,7 +399,6 @@ func (p *AuthorizeSecurityGroupIngressParams) SetUsersecuritygrouplist(v map[str
 		p.p = make(map[string]interface{})
 	}
 	p.p["usersecuritygrouplist"] = v
-	return
 }
 
 // You should always use this function to get a new AuthorizeSecurityGroupIngressParams instance,
@@ -520,7 +496,6 @@ func (p *CreateSecurityGroupParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateSecurityGroupParams) SetDescription(v string) {
@@ -528,7 +503,6 @@ func (p *CreateSecurityGroupParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateSecurityGroupParams) SetDomainid(v string) {
@@ -536,7 +510,6 @@ func (p *CreateSecurityGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateSecurityGroupParams) SetName(v string) {
@@ -544,7 +517,6 @@ func (p *CreateSecurityGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateSecurityGroupParams) SetProjectid(v string) {
@@ -552,7 +524,6 @@ func (p *CreateSecurityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateSecurityGroupParams instance,
@@ -646,7 +617,6 @@ func (p *DeleteSecurityGroupParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DeleteSecurityGroupParams) SetDomainid(v string) {
@@ -654,7 +624,6 @@ func (p *DeleteSecurityGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DeleteSecurityGroupParams) SetId(v string) {
@@ -662,7 +631,6 @@ func (p *DeleteSecurityGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DeleteSecurityGroupParams) SetName(v string) {
@@ -670,7 +638,6 @@ func (p *DeleteSecurityGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *DeleteSecurityGroupParams) SetProjectid(v string) {
@@ -678,7 +645,6 @@ func (p *DeleteSecurityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteSecurityGroupParams instance,
@@ -799,7 +765,6 @@ func (p *ListSecurityGroupsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetDomainid(v string) {
@@ -807,7 +772,6 @@ func (p *ListSecurityGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetId(v string) {
@@ -815,7 +779,6 @@ func (p *ListSecurityGroupsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetIsrecursive(v bool) {
@@ -823,7 +786,6 @@ func (p *ListSecurityGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetKeyword(v string) {
@@ -831,7 +793,6 @@ func (p *ListSecurityGroupsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetListall(v bool) {
@@ -839,7 +800,6 @@ func (p *ListSecurityGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetPage(v int) {
@@ -847,7 +807,6 @@ func (p *ListSecurityGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetPagesize(v int) {
@@ -855,7 +814,6 @@ func (p *ListSecurityGroupsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetProjectid(v string) {
@@ -863,7 +821,6 @@ func (p *ListSecurityGroupsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetSecuritygroupname(v string) {
@@ -871,7 +828,6 @@ func (p *ListSecurityGroupsParams) SetSecuritygroupname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupname"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetTags(v map[string]string) {
@@ -879,7 +835,6 @@ func (p *ListSecurityGroupsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListSecurityGroupsParams) SetVirtualmachineid(v string) {
@@ -887,7 +842,6 @@ func (p *ListSecurityGroupsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSecurityGroupsParams instance,
@@ -1052,7 +1006,6 @@ func (p *RevokeSecurityGroupEgressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RevokeSecurityGroupEgressParams instance,
@@ -1121,7 +1074,6 @@ func (p *RevokeSecurityGroupIngressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RevokeSecurityGroupIngressParams instance,

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -171,7 +171,6 @@ func (p *CreateServiceOfferingParams) SetBytesreadrate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadrate"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetBytesreadratemax(v int64) {
@@ -179,7 +178,6 @@ func (p *CreateServiceOfferingParams) SetBytesreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemax"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetBytesreadratemaxlength(v int64) {
@@ -187,7 +185,6 @@ func (p *CreateServiceOfferingParams) SetBytesreadratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemaxlength"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetByteswriterate(v int64) {
@@ -195,7 +192,6 @@ func (p *CreateServiceOfferingParams) SetByteswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriterate"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetByteswriteratemax(v int64) {
@@ -203,7 +199,6 @@ func (p *CreateServiceOfferingParams) SetByteswriteratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemax"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetByteswriteratemaxlength(v int64) {
@@ -211,7 +206,6 @@ func (p *CreateServiceOfferingParams) SetByteswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemaxlength"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetCpunumber(v int) {
@@ -219,7 +213,6 @@ func (p *CreateServiceOfferingParams) SetCpunumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cpunumber"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetCpuspeed(v int) {
@@ -227,7 +220,6 @@ func (p *CreateServiceOfferingParams) SetCpuspeed(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cpuspeed"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetCustomizediops(v bool) {
@@ -235,7 +227,6 @@ func (p *CreateServiceOfferingParams) SetCustomizediops(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customizediops"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetDeploymentplanner(v string) {
@@ -243,7 +234,6 @@ func (p *CreateServiceOfferingParams) SetDeploymentplanner(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deploymentplanner"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetDisplaytext(v string) {
@@ -251,7 +241,6 @@ func (p *CreateServiceOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetDomainid(v string) {
@@ -259,7 +248,6 @@ func (p *CreateServiceOfferingParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetHosttags(v string) {
@@ -267,7 +255,6 @@ func (p *CreateServiceOfferingParams) SetHosttags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hosttags"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetHypervisorsnapshotreserve(v int) {
@@ -275,7 +262,6 @@ func (p *CreateServiceOfferingParams) SetHypervisorsnapshotreserve(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisorsnapshotreserve"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIopsreadrate(v int64) {
@@ -283,7 +269,6 @@ func (p *CreateServiceOfferingParams) SetIopsreadrate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadrate"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIopsreadratemax(v int64) {
@@ -291,7 +276,6 @@ func (p *CreateServiceOfferingParams) SetIopsreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemax"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIopsreadratemaxlength(v int64) {
@@ -299,7 +283,6 @@ func (p *CreateServiceOfferingParams) SetIopsreadratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemaxlength"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIopswriterate(v int64) {
@@ -307,7 +290,6 @@ func (p *CreateServiceOfferingParams) SetIopswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriterate"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIopswriteratemax(v int64) {
@@ -315,7 +297,6 @@ func (p *CreateServiceOfferingParams) SetIopswriteratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemax"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIopswriteratemaxlength(v int64) {
@@ -323,7 +304,6 @@ func (p *CreateServiceOfferingParams) SetIopswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemaxlength"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIssystem(v bool) {
@@ -331,7 +311,6 @@ func (p *CreateServiceOfferingParams) SetIssystem(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["issystem"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetIsvolatile(v bool) {
@@ -339,7 +318,6 @@ func (p *CreateServiceOfferingParams) SetIsvolatile(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isvolatile"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetLimitcpuuse(v bool) {
@@ -347,7 +325,6 @@ func (p *CreateServiceOfferingParams) SetLimitcpuuse(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["limitcpuuse"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetMaxiops(v int64) {
@@ -355,7 +332,6 @@ func (p *CreateServiceOfferingParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetMemory(v int) {
@@ -363,7 +339,6 @@ func (p *CreateServiceOfferingParams) SetMemory(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["memory"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetMiniops(v int64) {
@@ -371,7 +346,6 @@ func (p *CreateServiceOfferingParams) SetMiniops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["miniops"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetName(v string) {
@@ -379,7 +353,6 @@ func (p *CreateServiceOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetNetworkrate(v int) {
@@ -387,7 +360,6 @@ func (p *CreateServiceOfferingParams) SetNetworkrate(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkrate"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetOfferha(v bool) {
@@ -395,7 +367,6 @@ func (p *CreateServiceOfferingParams) SetOfferha(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["offerha"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetProvisioningtype(v string) {
@@ -403,7 +374,6 @@ func (p *CreateServiceOfferingParams) SetProvisioningtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provisioningtype"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetServiceofferingdetails(v map[string]string) {
@@ -411,7 +381,6 @@ func (p *CreateServiceOfferingParams) SetServiceofferingdetails(v map[string]str
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingdetails"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetStoragetype(v string) {
@@ -419,7 +388,6 @@ func (p *CreateServiceOfferingParams) SetStoragetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storagetype"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetSystemvmtype(v string) {
@@ -427,7 +395,6 @@ func (p *CreateServiceOfferingParams) SetSystemvmtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["systemvmtype"] = v
-	return
 }
 
 func (p *CreateServiceOfferingParams) SetTags(v string) {
@@ -435,7 +402,6 @@ func (p *CreateServiceOfferingParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new CreateServiceOfferingParams instance,
@@ -531,7 +497,6 @@ func (p *DeleteServiceOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteServiceOfferingParams instance,
@@ -647,7 +612,6 @@ func (p *ListServiceOfferingsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetId(v string) {
@@ -655,7 +619,6 @@ func (p *ListServiceOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetIsrecursive(v bool) {
@@ -663,7 +626,6 @@ func (p *ListServiceOfferingsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetIssystem(v bool) {
@@ -671,7 +633,6 @@ func (p *ListServiceOfferingsParams) SetIssystem(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["issystem"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetKeyword(v string) {
@@ -679,7 +640,6 @@ func (p *ListServiceOfferingsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetListall(v bool) {
@@ -687,7 +647,6 @@ func (p *ListServiceOfferingsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetName(v string) {
@@ -695,7 +654,6 @@ func (p *ListServiceOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetPage(v int) {
@@ -703,7 +661,6 @@ func (p *ListServiceOfferingsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetPagesize(v int) {
@@ -711,7 +668,6 @@ func (p *ListServiceOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetSystemvmtype(v string) {
@@ -719,7 +675,6 @@ func (p *ListServiceOfferingsParams) SetSystemvmtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["systemvmtype"] = v
-	return
 }
 
 func (p *ListServiceOfferingsParams) SetVirtualmachineid(v string) {
@@ -727,7 +682,6 @@ func (p *ListServiceOfferingsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new ListServiceOfferingsParams instance,
@@ -915,7 +869,6 @@ func (p *UpdateServiceOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateServiceOfferingParams) SetId(v string) {
@@ -923,7 +876,6 @@ func (p *UpdateServiceOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateServiceOfferingParams) SetName(v string) {
@@ -931,7 +883,6 @@ func (p *UpdateServiceOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateServiceOfferingParams) SetSortkey(v int) {
@@ -939,7 +890,6 @@ func (p *UpdateServiceOfferingParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateServiceOfferingParams instance,

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -67,7 +67,6 @@ func (p *CreateSnapshotParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetAsyncbackup(v bool) {
@@ -75,7 +74,6 @@ func (p *CreateSnapshotParams) SetAsyncbackup(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["asyncbackup"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetDomainid(v string) {
@@ -83,7 +81,6 @@ func (p *CreateSnapshotParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetLocationtype(v string) {
@@ -91,7 +88,6 @@ func (p *CreateSnapshotParams) SetLocationtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["locationtype"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetName(v string) {
@@ -99,7 +95,6 @@ func (p *CreateSnapshotParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetPolicyid(v string) {
@@ -107,7 +102,6 @@ func (p *CreateSnapshotParams) SetPolicyid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["policyid"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetQuiescevm(v bool) {
@@ -115,7 +109,6 @@ func (p *CreateSnapshotParams) SetQuiescevm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["quiescevm"] = v
-	return
 }
 
 func (p *CreateSnapshotParams) SetVolumeid(v string) {
@@ -123,7 +116,6 @@ func (p *CreateSnapshotParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateSnapshotParams instance,
@@ -261,7 +253,6 @@ func (p *CreateSnapshotPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateSnapshotPolicyParams) SetIntervaltype(v string) {
@@ -269,7 +260,6 @@ func (p *CreateSnapshotPolicyParams) SetIntervaltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["intervaltype"] = v
-	return
 }
 
 func (p *CreateSnapshotPolicyParams) SetMaxsnaps(v int) {
@@ -277,7 +267,6 @@ func (p *CreateSnapshotPolicyParams) SetMaxsnaps(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxsnaps"] = v
-	return
 }
 
 func (p *CreateSnapshotPolicyParams) SetSchedule(v string) {
@@ -285,7 +274,6 @@ func (p *CreateSnapshotPolicyParams) SetSchedule(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["schedule"] = v
-	return
 }
 
 func (p *CreateSnapshotPolicyParams) SetTimezone(v string) {
@@ -293,7 +281,6 @@ func (p *CreateSnapshotPolicyParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
-	return
 }
 
 func (p *CreateSnapshotPolicyParams) SetVolumeid(v string) {
@@ -301,7 +288,6 @@ func (p *CreateSnapshotPolicyParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateSnapshotPolicyParams instance,
@@ -378,7 +364,6 @@ func (p *CreateVMSnapshotParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
-	return
 }
 
 func (p *CreateVMSnapshotParams) SetName(v string) {
@@ -386,7 +371,6 @@ func (p *CreateVMSnapshotParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateVMSnapshotParams) SetQuiescevm(v bool) {
@@ -394,7 +378,6 @@ func (p *CreateVMSnapshotParams) SetQuiescevm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["quiescevm"] = v
-	return
 }
 
 func (p *CreateVMSnapshotParams) SetSnapshotmemory(v bool) {
@@ -402,7 +385,6 @@ func (p *CreateVMSnapshotParams) SetSnapshotmemory(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshotmemory"] = v
-	return
 }
 
 func (p *CreateVMSnapshotParams) SetVirtualmachineid(v string) {
@@ -410,7 +392,6 @@ func (p *CreateVMSnapshotParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVMSnapshotParams instance,
@@ -499,7 +480,6 @@ func (p *DeleteSnapshotParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteSnapshotParams instance,
@@ -572,7 +552,6 @@ func (p *DeleteSnapshotPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DeleteSnapshotPoliciesParams) SetIds(v []string) {
@@ -580,7 +559,6 @@ func (p *DeleteSnapshotPoliciesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteSnapshotPoliciesParams instance,
@@ -660,7 +638,6 @@ func (p *DeleteVMSnapshotParams) SetVmsnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVMSnapshotParams instance,
@@ -747,7 +724,6 @@ func (p *ListSnapshotPoliciesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListSnapshotPoliciesParams) SetId(v string) {
@@ -755,7 +731,6 @@ func (p *ListSnapshotPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListSnapshotPoliciesParams) SetKeyword(v string) {
@@ -763,7 +738,6 @@ func (p *ListSnapshotPoliciesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSnapshotPoliciesParams) SetPage(v int) {
@@ -771,7 +745,6 @@ func (p *ListSnapshotPoliciesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSnapshotPoliciesParams) SetPagesize(v int) {
@@ -779,7 +752,6 @@ func (p *ListSnapshotPoliciesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSnapshotPoliciesParams) SetVolumeid(v string) {
@@ -787,7 +759,6 @@ func (p *ListSnapshotPoliciesParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSnapshotPoliciesParams instance,
@@ -937,7 +908,6 @@ func (p *ListSnapshotsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetDomainid(v string) {
@@ -945,7 +915,6 @@ func (p *ListSnapshotsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetId(v string) {
@@ -953,7 +922,6 @@ func (p *ListSnapshotsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetIds(v []string) {
@@ -961,7 +929,6 @@ func (p *ListSnapshotsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetIntervaltype(v string) {
@@ -969,7 +936,6 @@ func (p *ListSnapshotsParams) SetIntervaltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["intervaltype"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetIsrecursive(v bool) {
@@ -977,7 +943,6 @@ func (p *ListSnapshotsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetKeyword(v string) {
@@ -985,7 +950,6 @@ func (p *ListSnapshotsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetListall(v bool) {
@@ -993,7 +957,6 @@ func (p *ListSnapshotsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetName(v string) {
@@ -1001,7 +964,6 @@ func (p *ListSnapshotsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetPage(v int) {
@@ -1009,7 +971,6 @@ func (p *ListSnapshotsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetPagesize(v int) {
@@ -1017,7 +978,6 @@ func (p *ListSnapshotsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetProjectid(v string) {
@@ -1025,7 +985,6 @@ func (p *ListSnapshotsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetSnapshottype(v string) {
@@ -1033,7 +992,6 @@ func (p *ListSnapshotsParams) SetSnapshottype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshottype"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetTags(v map[string]string) {
@@ -1041,7 +999,6 @@ func (p *ListSnapshotsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetVolumeid(v string) {
@@ -1049,7 +1006,6 @@ func (p *ListSnapshotsParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 func (p *ListSnapshotsParams) SetZoneid(v string) {
@@ -1057,7 +1013,6 @@ func (p *ListSnapshotsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSnapshotsParams instance,
@@ -1293,7 +1248,6 @@ func (p *ListVMSnapshotParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetDomainid(v string) {
@@ -1301,7 +1255,6 @@ func (p *ListVMSnapshotParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetIsrecursive(v bool) {
@@ -1309,7 +1262,6 @@ func (p *ListVMSnapshotParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetKeyword(v string) {
@@ -1317,7 +1269,6 @@ func (p *ListVMSnapshotParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetListall(v bool) {
@@ -1325,7 +1276,6 @@ func (p *ListVMSnapshotParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetName(v string) {
@@ -1333,7 +1283,6 @@ func (p *ListVMSnapshotParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetPage(v int) {
@@ -1341,7 +1290,6 @@ func (p *ListVMSnapshotParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetPagesize(v int) {
@@ -1349,7 +1297,6 @@ func (p *ListVMSnapshotParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetProjectid(v string) {
@@ -1357,7 +1304,6 @@ func (p *ListVMSnapshotParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetState(v string) {
@@ -1365,7 +1311,6 @@ func (p *ListVMSnapshotParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetTags(v map[string]string) {
@@ -1373,7 +1318,6 @@ func (p *ListVMSnapshotParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetVirtualmachineid(v string) {
@@ -1381,7 +1325,6 @@ func (p *ListVMSnapshotParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetVmsnapshotid(v string) {
@@ -1389,7 +1332,6 @@ func (p *ListVMSnapshotParams) SetVmsnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotid"] = v
-	return
 }
 
 func (p *ListVMSnapshotParams) SetVmsnapshotids(v []string) {
@@ -1397,7 +1339,6 @@ func (p *ListVMSnapshotParams) SetVmsnapshotids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotids"] = v
-	return
 }
 
 // You should always use this function to get a new ListVMSnapshotParams instance,
@@ -1506,7 +1447,6 @@ func (p *RevertSnapshotParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RevertSnapshotParams instance,
@@ -1627,7 +1567,6 @@ func (p *RevertToVMSnapshotParams) SetVmsnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotid"] = v
-	return
 }
 
 // You should always use this function to get a new RevertToVMSnapshotParams instance,
@@ -1838,7 +1777,6 @@ func (p *UpdateSnapshotPolicyParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateSnapshotPolicyParams) SetFordisplay(v bool) {
@@ -1846,7 +1784,6 @@ func (p *UpdateSnapshotPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateSnapshotPolicyParams) SetId(v string) {
@@ -1854,7 +1791,6 @@ func (p *UpdateSnapshotPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateSnapshotPolicyParams instance,

--- a/cloudstack/StoragePoolService.go
+++ b/cloudstack/StoragePoolService.go
@@ -42,7 +42,6 @@ func (p *CancelStorageMaintenanceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new CancelStorageMaintenanceParams instance,
@@ -139,7 +138,6 @@ func (p *EnableStorageMaintenanceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new EnableStorageMaintenanceParams instance,
@@ -247,7 +245,6 @@ func (p *ListStorageProvidersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListStorageProvidersParams) SetPage(v int) {
@@ -255,7 +252,6 @@ func (p *ListStorageProvidersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListStorageProvidersParams) SetPagesize(v int) {
@@ -263,7 +259,6 @@ func (p *ListStorageProvidersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListStorageProvidersParams) SetType(v string) {
@@ -271,7 +266,6 @@ func (p *ListStorageProvidersParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 // You should always use this function to get a new ListStorageProvidersParams instance,

--- a/cloudstack/StratosphereSSPService.go
+++ b/cloudstack/StratosphereSSPService.go
@@ -57,7 +57,6 @@ func (p *AddStratosphereSspParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *AddStratosphereSspParams) SetPassword(v string) {
@@ -65,7 +64,6 @@ func (p *AddStratosphereSspParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddStratosphereSspParams) SetTenantuuid(v string) {
@@ -73,7 +71,6 @@ func (p *AddStratosphereSspParams) SetTenantuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tenantuuid"] = v
-	return
 }
 
 func (p *AddStratosphereSspParams) SetUrl(v string) {
@@ -81,7 +78,6 @@ func (p *AddStratosphereSspParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddStratosphereSspParams) SetUsername(v string) {
@@ -89,7 +85,6 @@ func (p *AddStratosphereSspParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 func (p *AddStratosphereSspParams) SetZoneid(v string) {
@@ -97,7 +92,6 @@ func (p *AddStratosphereSspParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddStratosphereSspParams instance,
@@ -155,7 +149,6 @@ func (p *DeleteStratosphereSspParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteStratosphereSspParams instance,

--- a/cloudstack/SwiftService.go
+++ b/cloudstack/SwiftService.go
@@ -52,7 +52,6 @@ func (p *AddSwiftParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AddSwiftParams) SetKey(v string) {
@@ -60,7 +59,6 @@ func (p *AddSwiftParams) SetKey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["key"] = v
-	return
 }
 
 func (p *AddSwiftParams) SetUrl(v string) {
@@ -68,7 +66,6 @@ func (p *AddSwiftParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddSwiftParams) SetUsername(v string) {
@@ -76,7 +73,6 @@ func (p *AddSwiftParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddSwiftParams instance,
@@ -148,7 +144,6 @@ func (p *ListSwiftsParams) SetId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListSwiftsParams) SetKeyword(v string) {
@@ -156,7 +151,6 @@ func (p *ListSwiftsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSwiftsParams) SetPage(v int) {
@@ -164,7 +158,6 @@ func (p *ListSwiftsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSwiftsParams) SetPagesize(v int) {
@@ -172,7 +165,6 @@ func (p *ListSwiftsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 // You should always use this function to get a new ListSwiftsParams instance,

--- a/cloudstack/SystemCapacityService.go
+++ b/cloudstack/SystemCapacityService.go
@@ -70,7 +70,6 @@ func (p *ListCapacityParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetFetchlatest(v bool) {
@@ -78,7 +77,6 @@ func (p *ListCapacityParams) SetFetchlatest(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fetchlatest"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetKeyword(v string) {
@@ -86,7 +84,6 @@ func (p *ListCapacityParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetPage(v int) {
@@ -94,7 +91,6 @@ func (p *ListCapacityParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetPagesize(v int) {
@@ -102,7 +98,6 @@ func (p *ListCapacityParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetPodid(v string) {
@@ -110,7 +105,6 @@ func (p *ListCapacityParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetSortby(v string) {
@@ -118,7 +112,6 @@ func (p *ListCapacityParams) SetSortby(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortby"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetType(v int) {
@@ -126,7 +119,6 @@ func (p *ListCapacityParams) SetType(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *ListCapacityParams) SetZoneid(v string) {
@@ -134,7 +126,6 @@ func (p *ListCapacityParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListCapacityParams instance,

--- a/cloudstack/SystemVMService.go
+++ b/cloudstack/SystemVMService.go
@@ -53,7 +53,6 @@ func (p *ChangeServiceForSystemVmParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ChangeServiceForSystemVmParams) SetId(v string) {
@@ -61,7 +60,6 @@ func (p *ChangeServiceForSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ChangeServiceForSystemVmParams) SetServiceofferingid(v string) {
@@ -69,7 +67,6 @@ func (p *ChangeServiceForSystemVmParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 // You should always use this function to get a new ChangeServiceForSystemVmParams instance,
@@ -150,7 +147,6 @@ func (p *DestroySystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DestroySystemVmParams instance,
@@ -282,7 +278,6 @@ func (p *ListSystemVmsParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetId(v string) {
@@ -290,7 +285,6 @@ func (p *ListSystemVmsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetKeyword(v string) {
@@ -298,7 +292,6 @@ func (p *ListSystemVmsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetName(v string) {
@@ -306,7 +299,6 @@ func (p *ListSystemVmsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetPage(v int) {
@@ -314,7 +306,6 @@ func (p *ListSystemVmsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetPagesize(v int) {
@@ -322,7 +313,6 @@ func (p *ListSystemVmsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetPodid(v string) {
@@ -330,7 +320,6 @@ func (p *ListSystemVmsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetState(v string) {
@@ -338,7 +327,6 @@ func (p *ListSystemVmsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetStorageid(v string) {
@@ -346,7 +334,6 @@ func (p *ListSystemVmsParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetSystemvmtype(v string) {
@@ -354,7 +341,6 @@ func (p *ListSystemVmsParams) SetSystemvmtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["systemvmtype"] = v
-	return
 }
 
 func (p *ListSystemVmsParams) SetZoneid(v string) {
@@ -362,7 +348,6 @@ func (p *ListSystemVmsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListSystemVmsParams instance,
@@ -532,7 +517,6 @@ func (p *MigrateSystemVmParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *MigrateSystemVmParams) SetVirtualmachineid(v string) {
@@ -540,7 +524,6 @@ func (p *MigrateSystemVmParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new MigrateSystemVmParams instance,
@@ -641,7 +624,6 @@ func (p *RebootSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RebootSystemVmParams instance,
@@ -750,7 +732,6 @@ func (p *ScaleSystemVmParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ScaleSystemVmParams) SetId(v string) {
@@ -758,7 +739,6 @@ func (p *ScaleSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ScaleSystemVmParams) SetServiceofferingid(v string) {
@@ -766,7 +746,6 @@ func (p *ScaleSystemVmParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 // You should always use this function to get a new ScaleSystemVmParams instance,
@@ -867,7 +846,6 @@ func (p *StartSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StartSystemVmParams instance,
@@ -971,7 +949,6 @@ func (p *StopSystemVmParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *StopSystemVmParams) SetId(v string) {
@@ -979,7 +956,6 @@ func (p *StopSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StopSystemVmParams instance,

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -54,7 +54,6 @@ func (p *CopyTemplateParams) SetDestzoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destzoneid"] = v
-	return
 }
 
 func (p *CopyTemplateParams) SetDestzoneids(v []string) {
@@ -62,7 +61,6 @@ func (p *CopyTemplateParams) SetDestzoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destzoneids"] = v
-	return
 }
 
 func (p *CopyTemplateParams) SetId(v string) {
@@ -70,7 +68,6 @@ func (p *CopyTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *CopyTemplateParams) SetSourcezoneid(v string) {
@@ -78,7 +75,6 @@ func (p *CopyTemplateParams) SetSourcezoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcezoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CopyTemplateParams instance,
@@ -277,7 +273,6 @@ func (p *CreateTemplateParams) SetBits(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bits"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetDetails(v map[string]string) {
@@ -285,7 +280,6 @@ func (p *CreateTemplateParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetDisplaytext(v string) {
@@ -293,7 +287,6 @@ func (p *CreateTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetIsdynamicallyscalable(v bool) {
@@ -301,7 +294,6 @@ func (p *CreateTemplateParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetIsfeatured(v bool) {
@@ -309,7 +301,6 @@ func (p *CreateTemplateParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetIspublic(v bool) {
@@ -317,7 +308,6 @@ func (p *CreateTemplateParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetName(v string) {
@@ -325,7 +315,6 @@ func (p *CreateTemplateParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetOstypeid(v string) {
@@ -333,7 +322,6 @@ func (p *CreateTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetPasswordenabled(v bool) {
@@ -341,7 +329,6 @@ func (p *CreateTemplateParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetProjectid(v string) {
@@ -349,7 +336,6 @@ func (p *CreateTemplateParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetRequireshvm(v bool) {
@@ -357,7 +343,6 @@ func (p *CreateTemplateParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetSnapshotid(v string) {
@@ -365,7 +350,6 @@ func (p *CreateTemplateParams) SetSnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshotid"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetSshkeyenabled(v bool) {
@@ -373,7 +357,6 @@ func (p *CreateTemplateParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetTemplatetag(v string) {
@@ -381,7 +364,6 @@ func (p *CreateTemplateParams) SetTemplatetag(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatetag"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetUrl(v string) {
@@ -389,7 +371,6 @@ func (p *CreateTemplateParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetVirtualmachineid(v string) {
@@ -397,7 +378,6 @@ func (p *CreateTemplateParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *CreateTemplateParams) SetVolumeid(v string) {
@@ -405,7 +385,6 @@ func (p *CreateTemplateParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateTemplateParams instance,
@@ -555,7 +534,6 @@ func (p *DeleteTemplateParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *DeleteTemplateParams) SetId(v string) {
@@ -563,7 +541,6 @@ func (p *DeleteTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DeleteTemplateParams) SetZoneid(v string) {
@@ -571,7 +548,6 @@ func (p *DeleteTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteTemplateParams instance,
@@ -649,7 +625,6 @@ func (p *ExtractTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ExtractTemplateParams) SetMode(v string) {
@@ -657,7 +632,6 @@ func (p *ExtractTemplateParams) SetMode(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mode"] = v
-	return
 }
 
 func (p *ExtractTemplateParams) SetUrl(v string) {
@@ -665,7 +639,6 @@ func (p *ExtractTemplateParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *ExtractTemplateParams) SetZoneid(v string) {
@@ -673,7 +646,6 @@ func (p *ExtractTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ExtractTemplateParams instance,
@@ -832,7 +804,6 @@ func (p *GetUploadParamsForTemplateParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetBits(v int) {
@@ -840,7 +811,6 @@ func (p *GetUploadParamsForTemplateParams) SetBits(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bits"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetChecksum(v string) {
@@ -848,7 +818,6 @@ func (p *GetUploadParamsForTemplateParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetDetails(v map[string]string) {
@@ -856,7 +825,6 @@ func (p *GetUploadParamsForTemplateParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetDisplaytext(v string) {
@@ -864,7 +832,6 @@ func (p *GetUploadParamsForTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetDomainid(v string) {
@@ -872,7 +839,6 @@ func (p *GetUploadParamsForTemplateParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetFormat(v string) {
@@ -880,7 +846,6 @@ func (p *GetUploadParamsForTemplateParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetHypervisor(v string) {
@@ -888,7 +853,6 @@ func (p *GetUploadParamsForTemplateParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetIsdynamicallyscalable(v bool) {
@@ -896,7 +860,6 @@ func (p *GetUploadParamsForTemplateParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetIsextractable(v bool) {
@@ -904,7 +867,6 @@ func (p *GetUploadParamsForTemplateParams) SetIsextractable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isextractable"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetIsfeatured(v bool) {
@@ -912,7 +874,6 @@ func (p *GetUploadParamsForTemplateParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetIspublic(v bool) {
@@ -920,7 +881,6 @@ func (p *GetUploadParamsForTemplateParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetIsrouting(v bool) {
@@ -928,7 +888,6 @@ func (p *GetUploadParamsForTemplateParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetName(v string) {
@@ -936,7 +895,6 @@ func (p *GetUploadParamsForTemplateParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetOstypeid(v string) {
@@ -944,7 +902,6 @@ func (p *GetUploadParamsForTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetPasswordenabled(v bool) {
@@ -952,7 +909,6 @@ func (p *GetUploadParamsForTemplateParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetProjectid(v string) {
@@ -960,7 +916,6 @@ func (p *GetUploadParamsForTemplateParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetRequireshvm(v bool) {
@@ -968,7 +923,6 @@ func (p *GetUploadParamsForTemplateParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetSshkeyenabled(v bool) {
@@ -976,7 +930,6 @@ func (p *GetUploadParamsForTemplateParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetTemplatetag(v string) {
@@ -984,7 +937,6 @@ func (p *GetUploadParamsForTemplateParams) SetTemplatetag(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatetag"] = v
-	return
 }
 
 func (p *GetUploadParamsForTemplateParams) SetZoneid(v string) {
@@ -992,7 +944,6 @@ func (p *GetUploadParamsForTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new GetUploadParamsForTemplateParams instance,
@@ -1054,7 +1005,6 @@ func (p *ListTemplatePermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ListTemplatePermissionsParams instance,
@@ -1207,7 +1157,6 @@ func (p *ListTemplatesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetDomainid(v string) {
@@ -1215,7 +1164,6 @@ func (p *ListTemplatesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetHypervisor(v string) {
@@ -1223,7 +1171,6 @@ func (p *ListTemplatesParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetId(v string) {
@@ -1231,7 +1178,6 @@ func (p *ListTemplatesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetIds(v []string) {
@@ -1239,7 +1185,6 @@ func (p *ListTemplatesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetIsrecursive(v bool) {
@@ -1247,7 +1192,6 @@ func (p *ListTemplatesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetKeyword(v string) {
@@ -1255,7 +1199,6 @@ func (p *ListTemplatesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetListall(v bool) {
@@ -1263,7 +1206,6 @@ func (p *ListTemplatesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetName(v string) {
@@ -1271,7 +1213,6 @@ func (p *ListTemplatesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetPage(v int) {
@@ -1279,7 +1220,6 @@ func (p *ListTemplatesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetPagesize(v int) {
@@ -1287,7 +1227,6 @@ func (p *ListTemplatesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetParenttemplateid(v string) {
@@ -1295,7 +1234,6 @@ func (p *ListTemplatesParams) SetParenttemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["parenttemplateid"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetProjectid(v string) {
@@ -1303,7 +1241,6 @@ func (p *ListTemplatesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetShowremoved(v bool) {
@@ -1311,7 +1248,6 @@ func (p *ListTemplatesParams) SetShowremoved(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showremoved"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetTags(v map[string]string) {
@@ -1319,7 +1255,6 @@ func (p *ListTemplatesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetTemplatefilter(v string) {
@@ -1327,7 +1262,6 @@ func (p *ListTemplatesParams) SetTemplatefilter(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatefilter"] = v
-	return
 }
 
 func (p *ListTemplatesParams) SetZoneid(v string) {
@@ -1335,7 +1269,6 @@ func (p *ListTemplatesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListTemplatesParams instance,
@@ -1553,7 +1486,6 @@ func (p *PrepareTemplateParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *PrepareTemplateParams) SetTemplateid(v string) {
@@ -1561,7 +1493,6 @@ func (p *PrepareTemplateParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *PrepareTemplateParams) SetZoneid(v string) {
@@ -1569,7 +1500,6 @@ func (p *PrepareTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new PrepareTemplateParams instance,
@@ -1774,7 +1704,6 @@ func (p *RegisterTemplateParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetBits(v int) {
@@ -1782,7 +1711,6 @@ func (p *RegisterTemplateParams) SetBits(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bits"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetChecksum(v string) {
@@ -1790,7 +1718,6 @@ func (p *RegisterTemplateParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetDetails(v map[string]string) {
@@ -1798,7 +1725,6 @@ func (p *RegisterTemplateParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetDirectdownload(v bool) {
@@ -1806,7 +1732,6 @@ func (p *RegisterTemplateParams) SetDirectdownload(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["directdownload"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetDisplaytext(v string) {
@@ -1814,7 +1739,6 @@ func (p *RegisterTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetDomainid(v string) {
@@ -1822,7 +1746,6 @@ func (p *RegisterTemplateParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetFormat(v string) {
@@ -1830,7 +1753,6 @@ func (p *RegisterTemplateParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetHypervisor(v string) {
@@ -1838,7 +1760,6 @@ func (p *RegisterTemplateParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetIsdynamicallyscalable(v bool) {
@@ -1846,7 +1767,6 @@ func (p *RegisterTemplateParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetIsextractable(v bool) {
@@ -1854,7 +1774,6 @@ func (p *RegisterTemplateParams) SetIsextractable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isextractable"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetIsfeatured(v bool) {
@@ -1862,7 +1781,6 @@ func (p *RegisterTemplateParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetIspublic(v bool) {
@@ -1870,7 +1788,6 @@ func (p *RegisterTemplateParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetIsrouting(v bool) {
@@ -1878,7 +1795,6 @@ func (p *RegisterTemplateParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetName(v string) {
@@ -1886,7 +1802,6 @@ func (p *RegisterTemplateParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetOstypeid(v string) {
@@ -1894,7 +1809,6 @@ func (p *RegisterTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetPasswordenabled(v bool) {
@@ -1902,7 +1816,6 @@ func (p *RegisterTemplateParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetProjectid(v string) {
@@ -1910,7 +1823,6 @@ func (p *RegisterTemplateParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetRequireshvm(v bool) {
@@ -1918,7 +1830,6 @@ func (p *RegisterTemplateParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetSshkeyenabled(v bool) {
@@ -1926,7 +1837,6 @@ func (p *RegisterTemplateParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetTemplatetag(v string) {
@@ -1934,7 +1844,6 @@ func (p *RegisterTemplateParams) SetTemplatetag(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatetag"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetUrl(v string) {
@@ -1942,7 +1851,6 @@ func (p *RegisterTemplateParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetZoneid(v string) {
@@ -1950,7 +1858,6 @@ func (p *RegisterTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 func (p *RegisterTemplateParams) SetZoneids(v []string) {
@@ -1958,7 +1865,6 @@ func (p *RegisterTemplateParams) SetZoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneids"] = v
-	return
 }
 
 // You should always use this function to get a new RegisterTemplateParams instance,
@@ -2139,7 +2045,6 @@ func (p *UpdateTemplateParams) SetBootable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootable"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetCleanupdetails(v bool) {
@@ -2147,7 +2052,6 @@ func (p *UpdateTemplateParams) SetCleanupdetails(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanupdetails"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetDetails(v map[string]string) {
@@ -2155,7 +2059,6 @@ func (p *UpdateTemplateParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetDisplaytext(v string) {
@@ -2163,7 +2066,6 @@ func (p *UpdateTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetFormat(v string) {
@@ -2171,7 +2073,6 @@ func (p *UpdateTemplateParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetId(v string) {
@@ -2179,7 +2080,6 @@ func (p *UpdateTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetIsdynamicallyscalable(v bool) {
@@ -2187,7 +2087,6 @@ func (p *UpdateTemplateParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetIsrouting(v bool) {
@@ -2195,7 +2094,6 @@ func (p *UpdateTemplateParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetName(v string) {
@@ -2203,7 +2101,6 @@ func (p *UpdateTemplateParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetOstypeid(v string) {
@@ -2211,7 +2108,6 @@ func (p *UpdateTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetPasswordenabled(v bool) {
@@ -2219,7 +2115,6 @@ func (p *UpdateTemplateParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetRequireshvm(v bool) {
@@ -2227,7 +2122,6 @@ func (p *UpdateTemplateParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetSortkey(v int) {
@@ -2235,7 +2129,6 @@ func (p *UpdateTemplateParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
-	return
 }
 
 func (p *UpdateTemplateParams) SetSshkeyenabled(v bool) {
@@ -2243,7 +2136,6 @@ func (p *UpdateTemplateParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateTemplateParams instance,
@@ -2387,7 +2279,6 @@ func (p *UpdateTemplatePermissionsParams) SetAccounts(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounts"] = v
-	return
 }
 
 func (p *UpdateTemplatePermissionsParams) SetId(v string) {
@@ -2395,7 +2286,6 @@ func (p *UpdateTemplatePermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateTemplatePermissionsParams) SetIsextractable(v bool) {
@@ -2403,7 +2293,6 @@ func (p *UpdateTemplatePermissionsParams) SetIsextractable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isextractable"] = v
-	return
 }
 
 func (p *UpdateTemplatePermissionsParams) SetIsfeatured(v bool) {
@@ -2411,7 +2300,6 @@ func (p *UpdateTemplatePermissionsParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
-	return
 }
 
 func (p *UpdateTemplatePermissionsParams) SetIspublic(v bool) {
@@ -2419,7 +2307,6 @@ func (p *UpdateTemplatePermissionsParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *UpdateTemplatePermissionsParams) SetOp(v string) {
@@ -2427,7 +2314,6 @@ func (p *UpdateTemplatePermissionsParams) SetOp(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["op"] = v
-	return
 }
 
 func (p *UpdateTemplatePermissionsParams) SetProjectids(v []string) {
@@ -2435,7 +2321,6 @@ func (p *UpdateTemplatePermissionsParams) SetProjectids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectids"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateTemplatePermissionsParams instance,
@@ -2531,7 +2416,6 @@ func (p *UpgradeRouterTemplateParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpgradeRouterTemplateParams) SetClusterid(v string) {
@@ -2539,7 +2423,6 @@ func (p *UpgradeRouterTemplateParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *UpgradeRouterTemplateParams) SetDomainid(v string) {
@@ -2547,7 +2430,6 @@ func (p *UpgradeRouterTemplateParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UpgradeRouterTemplateParams) SetId(v string) {
@@ -2555,7 +2437,6 @@ func (p *UpgradeRouterTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpgradeRouterTemplateParams) SetPodid(v string) {
@@ -2563,7 +2444,6 @@ func (p *UpgradeRouterTemplateParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *UpgradeRouterTemplateParams) SetZoneid(v string) {
@@ -2571,7 +2451,6 @@ func (p *UpgradeRouterTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new UpgradeRouterTemplateParams instance,

--- a/cloudstack/UCSService.go
+++ b/cloudstack/UCSService.go
@@ -56,7 +56,6 @@ func (p *AddUcsManagerParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *AddUcsManagerParams) SetPassword(v string) {
@@ -64,7 +63,6 @@ func (p *AddUcsManagerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddUcsManagerParams) SetUrl(v string) {
@@ -72,7 +70,6 @@ func (p *AddUcsManagerParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddUcsManagerParams) SetUsername(v string) {
@@ -80,7 +77,6 @@ func (p *AddUcsManagerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 func (p *AddUcsManagerParams) SetZoneid(v string) {
@@ -88,7 +84,6 @@ func (p *AddUcsManagerParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddUcsManagerParams instance,
@@ -153,7 +148,6 @@ func (p *AssociateUcsProfileToBladeParams) SetBladeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bladeid"] = v
-	return
 }
 
 func (p *AssociateUcsProfileToBladeParams) SetProfiledn(v string) {
@@ -161,7 +155,6 @@ func (p *AssociateUcsProfileToBladeParams) SetProfiledn(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["profiledn"] = v
-	return
 }
 
 func (p *AssociateUcsProfileToBladeParams) SetUcsmanagerid(v string) {
@@ -169,7 +162,6 @@ func (p *AssociateUcsProfileToBladeParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
-	return
 }
 
 // You should always use this function to get a new AssociateUcsProfileToBladeParams instance,
@@ -248,7 +240,6 @@ func (p *DeleteUcsManagerParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteUcsManagerParams instance,
@@ -340,7 +331,6 @@ func (p *ListUcsBladesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListUcsBladesParams) SetPage(v int) {
@@ -348,7 +338,6 @@ func (p *ListUcsBladesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListUcsBladesParams) SetPagesize(v int) {
@@ -356,7 +345,6 @@ func (p *ListUcsBladesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListUcsBladesParams) SetUcsmanagerid(v string) {
@@ -364,7 +352,6 @@ func (p *ListUcsBladesParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
-	return
 }
 
 // You should always use this function to get a new ListUcsBladesParams instance,
@@ -440,7 +427,6 @@ func (p *ListUcsManagersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListUcsManagersParams) SetKeyword(v string) {
@@ -448,7 +434,6 @@ func (p *ListUcsManagersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListUcsManagersParams) SetPage(v int) {
@@ -456,7 +441,6 @@ func (p *ListUcsManagersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListUcsManagersParams) SetPagesize(v int) {
@@ -464,7 +448,6 @@ func (p *ListUcsManagersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListUcsManagersParams) SetZoneid(v string) {
@@ -472,7 +455,6 @@ func (p *ListUcsManagersParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListUcsManagersParams instance,
@@ -626,7 +608,6 @@ func (p *ListUcsProfilesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListUcsProfilesParams) SetPage(v int) {
@@ -634,7 +615,6 @@ func (p *ListUcsProfilesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListUcsProfilesParams) SetPagesize(v int) {
@@ -642,7 +622,6 @@ func (p *ListUcsProfilesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListUcsProfilesParams) SetUcsmanagerid(v string) {
@@ -650,7 +629,6 @@ func (p *ListUcsProfilesParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
-	return
 }
 
 // You should always use this function to get a new ListUcsProfilesParams instance,

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -52,7 +52,6 @@ func (p *AddTrafficMonitorParams) SetExcludezones(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["excludezones"] = v
-	return
 }
 
 func (p *AddTrafficMonitorParams) SetIncludezones(v string) {
@@ -60,7 +59,6 @@ func (p *AddTrafficMonitorParams) SetIncludezones(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["includezones"] = v
-	return
 }
 
 func (p *AddTrafficMonitorParams) SetUrl(v string) {
@@ -68,7 +66,6 @@ func (p *AddTrafficMonitorParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *AddTrafficMonitorParams) SetZoneid(v string) {
@@ -76,7 +73,6 @@ func (p *AddTrafficMonitorParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new AddTrafficMonitorParams instance,
@@ -158,7 +154,6 @@ func (p *AddTrafficTypeParams) SetHypervnetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervnetworklabel"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetIsolationmethod(v string) {
@@ -166,7 +161,6 @@ func (p *AddTrafficTypeParams) SetIsolationmethod(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isolationmethod"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetKvmnetworklabel(v string) {
@@ -174,7 +168,6 @@ func (p *AddTrafficTypeParams) SetKvmnetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["kvmnetworklabel"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetOvm3networklabel(v string) {
@@ -182,7 +175,6 @@ func (p *AddTrafficTypeParams) SetOvm3networklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3networklabel"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetPhysicalnetworkid(v string) {
@@ -190,7 +182,6 @@ func (p *AddTrafficTypeParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetTraffictype(v string) {
@@ -198,7 +189,6 @@ func (p *AddTrafficTypeParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetVlan(v string) {
@@ -206,7 +196,6 @@ func (p *AddTrafficTypeParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetVmwarenetworklabel(v string) {
@@ -214,7 +203,6 @@ func (p *AddTrafficTypeParams) SetVmwarenetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmwarenetworklabel"] = v
-	return
 }
 
 func (p *AddTrafficTypeParams) SetXennetworklabel(v string) {
@@ -222,7 +210,6 @@ func (p *AddTrafficTypeParams) SetXennetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["xennetworklabel"] = v
-	return
 }
 
 // You should always use this function to get a new AddTrafficTypeParams instance,
@@ -303,7 +290,6 @@ func (p *DeleteTrafficMonitorParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteTrafficMonitorParams instance,
@@ -384,7 +370,6 @@ func (p *DeleteTrafficTypeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteTrafficTypeParams instance,
@@ -459,7 +444,6 @@ func (p *GenerateUsageRecordsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *GenerateUsageRecordsParams) SetEnddate(v string) {
@@ -467,7 +451,6 @@ func (p *GenerateUsageRecordsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *GenerateUsageRecordsParams) SetStartdate(v string) {
@@ -475,7 +458,6 @@ func (p *GenerateUsageRecordsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 // You should always use this function to get a new GenerateUsageRecordsParams instance,
@@ -568,7 +550,6 @@ func (p *ListTrafficMonitorsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListTrafficMonitorsParams) SetPage(v int) {
@@ -576,7 +557,6 @@ func (p *ListTrafficMonitorsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListTrafficMonitorsParams) SetPagesize(v int) {
@@ -584,7 +564,6 @@ func (p *ListTrafficMonitorsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListTrafficMonitorsParams) SetZoneid(v string) {
@@ -592,7 +571,6 @@ func (p *ListTrafficMonitorsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListTrafficMonitorsParams instance,
@@ -665,7 +643,6 @@ func (p *ListTrafficTypeImplementorsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListTrafficTypeImplementorsParams) SetPage(v int) {
@@ -673,7 +650,6 @@ func (p *ListTrafficTypeImplementorsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListTrafficTypeImplementorsParams) SetPagesize(v int) {
@@ -681,7 +657,6 @@ func (p *ListTrafficTypeImplementorsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListTrafficTypeImplementorsParams) SetTraffictype(v string) {
@@ -689,7 +664,6 @@ func (p *ListTrafficTypeImplementorsParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
-	return
 }
 
 // You should always use this function to get a new ListTrafficTypeImplementorsParams instance,
@@ -758,7 +732,6 @@ func (p *ListTrafficTypesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListTrafficTypesParams) SetPage(v int) {
@@ -766,7 +739,6 @@ func (p *ListTrafficTypesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListTrafficTypesParams) SetPagesize(v int) {
@@ -774,7 +746,6 @@ func (p *ListTrafficTypesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListTrafficTypesParams) SetPhysicalnetworkid(v string) {
@@ -782,7 +753,6 @@ func (p *ListTrafficTypesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 // You should always use this function to get a new ListTrafficTypesParams instance,
@@ -920,7 +890,6 @@ func (p *ListUsageRecordsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetAccountid(v string) {
@@ -928,7 +897,6 @@ func (p *ListUsageRecordsParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetDomainid(v string) {
@@ -936,7 +904,6 @@ func (p *ListUsageRecordsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetEnddate(v string) {
@@ -944,7 +911,6 @@ func (p *ListUsageRecordsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetIncludetags(v bool) {
@@ -952,7 +918,6 @@ func (p *ListUsageRecordsParams) SetIncludetags(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["includetags"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetKeyword(v string) {
@@ -960,7 +925,6 @@ func (p *ListUsageRecordsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetPage(v int) {
@@ -968,7 +932,6 @@ func (p *ListUsageRecordsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetPagesize(v int) {
@@ -976,7 +939,6 @@ func (p *ListUsageRecordsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetProjectid(v string) {
@@ -984,7 +946,6 @@ func (p *ListUsageRecordsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetStartdate(v string) {
@@ -992,7 +953,6 @@ func (p *ListUsageRecordsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetType(v int64) {
@@ -1000,7 +960,6 @@ func (p *ListUsageRecordsParams) SetType(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *ListUsageRecordsParams) SetUsageid(v string) {
@@ -1008,7 +967,6 @@ func (p *ListUsageRecordsParams) SetUsageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usageid"] = v
-	return
 }
 
 // You should always use this function to get a new ListUsageRecordsParams instance,
@@ -1143,7 +1101,6 @@ func (p *RemoveRawUsageRecordsParams) SetInterval(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["interval"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveRawUsageRecordsParams instance,
@@ -1239,7 +1196,6 @@ func (p *UpdateTrafficTypeParams) SetHypervnetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervnetworklabel"] = v
-	return
 }
 
 func (p *UpdateTrafficTypeParams) SetId(v string) {
@@ -1247,7 +1203,6 @@ func (p *UpdateTrafficTypeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateTrafficTypeParams) SetKvmnetworklabel(v string) {
@@ -1255,7 +1210,6 @@ func (p *UpdateTrafficTypeParams) SetKvmnetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["kvmnetworklabel"] = v
-	return
 }
 
 func (p *UpdateTrafficTypeParams) SetOvm3networklabel(v string) {
@@ -1263,7 +1217,6 @@ func (p *UpdateTrafficTypeParams) SetOvm3networklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3networklabel"] = v
-	return
 }
 
 func (p *UpdateTrafficTypeParams) SetVmwarenetworklabel(v string) {
@@ -1271,7 +1224,6 @@ func (p *UpdateTrafficTypeParams) SetVmwarenetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmwarenetworklabel"] = v
-	return
 }
 
 func (p *UpdateTrafficTypeParams) SetXennetworklabel(v string) {
@@ -1279,7 +1231,6 @@ func (p *UpdateTrafficTypeParams) SetXennetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["xennetworklabel"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateTrafficTypeParams instance,

--- a/cloudstack/UserService.go
+++ b/cloudstack/UserService.go
@@ -68,7 +68,6 @@ func (p *CreateUserParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateUserParams) SetDomainid(v string) {
@@ -76,7 +75,6 @@ func (p *CreateUserParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateUserParams) SetEmail(v string) {
@@ -84,7 +82,6 @@ func (p *CreateUserParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
-	return
 }
 
 func (p *CreateUserParams) SetFirstname(v string) {
@@ -92,7 +89,6 @@ func (p *CreateUserParams) SetFirstname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["firstname"] = v
-	return
 }
 
 func (p *CreateUserParams) SetLastname(v string) {
@@ -100,7 +96,6 @@ func (p *CreateUserParams) SetLastname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lastname"] = v
-	return
 }
 
 func (p *CreateUserParams) SetPassword(v string) {
@@ -108,7 +103,6 @@ func (p *CreateUserParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *CreateUserParams) SetTimezone(v string) {
@@ -116,7 +110,6 @@ func (p *CreateUserParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
-	return
 }
 
 func (p *CreateUserParams) SetUserid(v string) {
@@ -124,7 +117,6 @@ func (p *CreateUserParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
-	return
 }
 
 func (p *CreateUserParams) SetUsername(v string) {
@@ -132,7 +124,6 @@ func (p *CreateUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new CreateUserParams instance,
@@ -214,7 +205,6 @@ func (p *DeleteUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteUserParams instance,
@@ -295,7 +285,6 @@ func (p *DisableUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DisableUserParams instance,
@@ -388,7 +377,6 @@ func (p *EnableUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new EnableUserParams instance,
@@ -461,7 +449,6 @@ func (p *GetUserParams) SetUserapikey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userapikey"] = v
-	return
 }
 
 // You should always use this function to get a new GetUserParams instance,
@@ -534,7 +521,6 @@ func (p *GetVirtualMachineUserDataParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new GetVirtualMachineUserDataParams instance,
@@ -627,7 +613,6 @@ func (p *ListUsersParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListUsersParams) SetAccounttype(v int64) {
@@ -635,7 +620,6 @@ func (p *ListUsersParams) SetAccounttype(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
-	return
 }
 
 func (p *ListUsersParams) SetDomainid(v string) {
@@ -643,7 +627,6 @@ func (p *ListUsersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListUsersParams) SetId(v string) {
@@ -651,7 +634,6 @@ func (p *ListUsersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListUsersParams) SetIsrecursive(v bool) {
@@ -659,7 +641,6 @@ func (p *ListUsersParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListUsersParams) SetKeyword(v string) {
@@ -667,7 +648,6 @@ func (p *ListUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListUsersParams) SetListall(v bool) {
@@ -675,7 +655,6 @@ func (p *ListUsersParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListUsersParams) SetPage(v int) {
@@ -683,7 +662,6 @@ func (p *ListUsersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListUsersParams) SetPagesize(v int) {
@@ -691,7 +669,6 @@ func (p *ListUsersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListUsersParams) SetState(v string) {
@@ -699,7 +676,6 @@ func (p *ListUsersParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListUsersParams) SetUsername(v string) {
@@ -707,7 +683,6 @@ func (p *ListUsersParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new ListUsersParams instance,
@@ -817,7 +792,6 @@ func (p *LockUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new LockUserParams instance,
@@ -890,7 +864,6 @@ func (p *RegisterUserKeysParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RegisterUserKeysParams instance,
@@ -975,7 +948,6 @@ func (p *UpdateUserParams) SetCurrentpassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["currentpassword"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetEmail(v string) {
@@ -983,7 +955,6 @@ func (p *UpdateUserParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetFirstname(v string) {
@@ -991,7 +962,6 @@ func (p *UpdateUserParams) SetFirstname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["firstname"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetId(v string) {
@@ -999,7 +969,6 @@ func (p *UpdateUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetLastname(v string) {
@@ -1007,7 +976,6 @@ func (p *UpdateUserParams) SetLastname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lastname"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetPassword(v string) {
@@ -1015,7 +983,6 @@ func (p *UpdateUserParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetTimezone(v string) {
@@ -1023,7 +990,6 @@ func (p *UpdateUserParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetUserapikey(v string) {
@@ -1031,7 +997,6 @@ func (p *UpdateUserParams) SetUserapikey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userapikey"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetUsername(v string) {
@@ -1039,7 +1004,6 @@ func (p *UpdateUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 func (p *UpdateUserParams) SetUsersecretkey(v string) {
@@ -1047,7 +1011,6 @@ func (p *UpdateUserParams) SetUsersecretkey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usersecretkey"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateUserParams instance,

--- a/cloudstack/VLANService.go
+++ b/cloudstack/VLANService.go
@@ -97,7 +97,6 @@ func (p *CreateVlanIpRangeParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetDomainid(v string) {
@@ -105,7 +104,6 @@ func (p *CreateVlanIpRangeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetEndip(v string) {
@@ -113,7 +111,6 @@ func (p *CreateVlanIpRangeParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetEndipv6(v string) {
@@ -121,7 +118,6 @@ func (p *CreateVlanIpRangeParams) SetEndipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endipv6"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetForsystemvms(v bool) {
@@ -129,7 +125,6 @@ func (p *CreateVlanIpRangeParams) SetForsystemvms(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forsystemvms"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetForvirtualnetwork(v bool) {
@@ -137,7 +132,6 @@ func (p *CreateVlanIpRangeParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetGateway(v string) {
@@ -145,7 +139,6 @@ func (p *CreateVlanIpRangeParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetIp6cidr(v string) {
@@ -153,7 +146,6 @@ func (p *CreateVlanIpRangeParams) SetIp6cidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6cidr"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetIp6gateway(v string) {
@@ -161,7 +153,6 @@ func (p *CreateVlanIpRangeParams) SetIp6gateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6gateway"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetNetmask(v string) {
@@ -169,7 +160,6 @@ func (p *CreateVlanIpRangeParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetNetworkid(v string) {
@@ -177,7 +167,6 @@ func (p *CreateVlanIpRangeParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetPhysicalnetworkid(v string) {
@@ -185,7 +174,6 @@ func (p *CreateVlanIpRangeParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetPodid(v string) {
@@ -193,7 +181,6 @@ func (p *CreateVlanIpRangeParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetProjectid(v string) {
@@ -201,7 +188,6 @@ func (p *CreateVlanIpRangeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetStartip(v string) {
@@ -209,7 +195,6 @@ func (p *CreateVlanIpRangeParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetStartipv6(v string) {
@@ -217,7 +202,6 @@ func (p *CreateVlanIpRangeParams) SetStartipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startipv6"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetVlan(v string) {
@@ -225,7 +209,6 @@ func (p *CreateVlanIpRangeParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *CreateVlanIpRangeParams) SetZoneid(v string) {
@@ -233,7 +216,6 @@ func (p *CreateVlanIpRangeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVlanIpRangeParams instance,
@@ -319,7 +301,6 @@ func (p *DedicateGuestVlanRangeParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DedicateGuestVlanRangeParams) SetDomainid(v string) {
@@ -327,7 +308,6 @@ func (p *DedicateGuestVlanRangeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DedicateGuestVlanRangeParams) SetPhysicalnetworkid(v string) {
@@ -335,7 +315,6 @@ func (p *DedicateGuestVlanRangeParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *DedicateGuestVlanRangeParams) SetProjectid(v string) {
@@ -343,7 +322,6 @@ func (p *DedicateGuestVlanRangeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *DedicateGuestVlanRangeParams) SetVlanrange(v string) {
@@ -351,7 +329,6 @@ func (p *DedicateGuestVlanRangeParams) SetVlanrange(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlanrange"] = v
-	return
 }
 
 // You should always use this function to get a new DedicateGuestVlanRangeParams instance,
@@ -413,7 +390,6 @@ func (p *DeleteVlanIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVlanIpRangeParams instance,
@@ -523,7 +499,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetDomainid(v string) {
@@ -531,7 +506,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetGuestvlanrange(v string) {
@@ -539,7 +513,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetGuestvlanrange(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestvlanrange"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetId(v string) {
@@ -547,7 +520,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetKeyword(v string) {
@@ -555,7 +527,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetPage(v int) {
@@ -563,7 +534,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetPagesize(v int) {
@@ -571,7 +541,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetPhysicalnetworkid(v string) {
@@ -579,7 +548,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetProjectid(v string) {
@@ -587,7 +555,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) SetZoneid(v string) {
@@ -595,7 +562,6 @@ func (p *ListDedicatedGuestVlanRangesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListDedicatedGuestVlanRangesParams instance,
@@ -732,7 +698,6 @@ func (p *ListVlanIpRangesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetDomainid(v string) {
@@ -740,7 +705,6 @@ func (p *ListVlanIpRangesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetForvirtualnetwork(v bool) {
@@ -748,7 +712,6 @@ func (p *ListVlanIpRangesParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetId(v string) {
@@ -756,7 +719,6 @@ func (p *ListVlanIpRangesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetKeyword(v string) {
@@ -764,7 +726,6 @@ func (p *ListVlanIpRangesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetNetworkid(v string) {
@@ -772,7 +733,6 @@ func (p *ListVlanIpRangesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetPage(v int) {
@@ -780,7 +740,6 @@ func (p *ListVlanIpRangesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetPagesize(v int) {
@@ -788,7 +747,6 @@ func (p *ListVlanIpRangesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetPhysicalnetworkid(v string) {
@@ -796,7 +754,6 @@ func (p *ListVlanIpRangesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetPodid(v string) {
@@ -804,7 +761,6 @@ func (p *ListVlanIpRangesParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetProjectid(v string) {
@@ -812,7 +768,6 @@ func (p *ListVlanIpRangesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetVlan(v string) {
@@ -820,7 +775,6 @@ func (p *ListVlanIpRangesParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *ListVlanIpRangesParams) SetZoneid(v string) {
@@ -828,7 +782,6 @@ func (p *ListVlanIpRangesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVlanIpRangesParams instance,
@@ -940,7 +893,6 @@ func (p *ReleaseDedicatedGuestVlanRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ReleaseDedicatedGuestVlanRangeParams instance,

--- a/cloudstack/VMGroupService.go
+++ b/cloudstack/VMGroupService.go
@@ -53,7 +53,6 @@ func (p *CreateInstanceGroupParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateInstanceGroupParams) SetDomainid(v string) {
@@ -61,7 +60,6 @@ func (p *CreateInstanceGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateInstanceGroupParams) SetName(v string) {
@@ -69,7 +67,6 @@ func (p *CreateInstanceGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateInstanceGroupParams) SetProjectid(v string) {
@@ -77,7 +74,6 @@ func (p *CreateInstanceGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateInstanceGroupParams instance,
@@ -137,7 +133,6 @@ func (p *DeleteInstanceGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteInstanceGroupParams instance,
@@ -249,7 +244,6 @@ func (p *ListInstanceGroupsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetDomainid(v string) {
@@ -257,7 +251,6 @@ func (p *ListInstanceGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetId(v string) {
@@ -265,7 +258,6 @@ func (p *ListInstanceGroupsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetIsrecursive(v bool) {
@@ -273,7 +265,6 @@ func (p *ListInstanceGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetKeyword(v string) {
@@ -281,7 +272,6 @@ func (p *ListInstanceGroupsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetListall(v bool) {
@@ -289,7 +279,6 @@ func (p *ListInstanceGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetName(v string) {
@@ -297,7 +286,6 @@ func (p *ListInstanceGroupsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetPage(v int) {
@@ -305,7 +293,6 @@ func (p *ListInstanceGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetPagesize(v int) {
@@ -313,7 +300,6 @@ func (p *ListInstanceGroupsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListInstanceGroupsParams) SetProjectid(v string) {
@@ -321,7 +307,6 @@ func (p *ListInstanceGroupsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new ListInstanceGroupsParams instance,
@@ -471,7 +456,6 @@ func (p *UpdateInstanceGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateInstanceGroupParams) SetName(v string) {
@@ -479,7 +463,6 @@ func (p *UpdateInstanceGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateInstanceGroupParams instance,

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -69,7 +69,6 @@ func (p *CreatePrivateGatewayParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetGateway(v string) {
@@ -77,7 +76,6 @@ func (p *CreatePrivateGatewayParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetIpaddress(v string) {
@@ -85,7 +83,6 @@ func (p *CreatePrivateGatewayParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetNetmask(v string) {
@@ -93,7 +90,6 @@ func (p *CreatePrivateGatewayParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetNetworkofferingid(v string) {
@@ -101,7 +97,6 @@ func (p *CreatePrivateGatewayParams) SetNetworkofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkofferingid"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetPhysicalnetworkid(v string) {
@@ -109,7 +104,6 @@ func (p *CreatePrivateGatewayParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetSourcenatsupported(v bool) {
@@ -117,7 +111,6 @@ func (p *CreatePrivateGatewayParams) SetSourcenatsupported(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcenatsupported"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetVlan(v string) {
@@ -125,7 +118,6 @@ func (p *CreatePrivateGatewayParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *CreatePrivateGatewayParams) SetVpcid(v string) {
@@ -133,7 +125,6 @@ func (p *CreatePrivateGatewayParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new CreatePrivateGatewayParams instance,
@@ -229,7 +220,6 @@ func (p *CreateStaticRouteParams) SetCidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidr"] = v
-	return
 }
 
 func (p *CreateStaticRouteParams) SetGatewayid(v string) {
@@ -237,7 +227,6 @@ func (p *CreateStaticRouteParams) SetGatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gatewayid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateStaticRouteParams instance,
@@ -353,7 +342,6 @@ func (p *CreateVPCParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetCidr(v string) {
@@ -361,7 +349,6 @@ func (p *CreateVPCParams) SetCidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidr"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetDisplaytext(v string) {
@@ -369,7 +356,6 @@ func (p *CreateVPCParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetDomainid(v string) {
@@ -377,7 +363,6 @@ func (p *CreateVPCParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetFordisplay(v bool) {
@@ -385,7 +370,6 @@ func (p *CreateVPCParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetName(v string) {
@@ -393,7 +377,6 @@ func (p *CreateVPCParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetNetworkdomain(v string) {
@@ -401,7 +384,6 @@ func (p *CreateVPCParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetProjectid(v string) {
@@ -409,7 +391,6 @@ func (p *CreateVPCParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetStart(v bool) {
@@ -417,7 +398,6 @@ func (p *CreateVPCParams) SetStart(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["start"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetVpcofferingid(v string) {
@@ -425,7 +405,6 @@ func (p *CreateVPCParams) SetVpcofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcofferingid"] = v
-	return
 }
 
 func (p *CreateVPCParams) SetZoneid(v string) {
@@ -433,7 +412,6 @@ func (p *CreateVPCParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVPCParams instance,
@@ -653,7 +631,6 @@ func (p *CreateVPCOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *CreateVPCOfferingParams) SetName(v string) {
@@ -661,7 +638,6 @@ func (p *CreateVPCOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateVPCOfferingParams) SetServicecapabilitylist(v map[string]string) {
@@ -669,7 +645,6 @@ func (p *CreateVPCOfferingParams) SetServicecapabilitylist(v map[string]string) 
 		p.p = make(map[string]interface{})
 	}
 	p.p["servicecapabilitylist"] = v
-	return
 }
 
 func (p *CreateVPCOfferingParams) SetServiceofferingid(v string) {
@@ -677,7 +652,6 @@ func (p *CreateVPCOfferingParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *CreateVPCOfferingParams) SetServiceproviderlist(v map[string]string) {
@@ -685,7 +659,6 @@ func (p *CreateVPCOfferingParams) SetServiceproviderlist(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceproviderlist"] = v
-	return
 }
 
 func (p *CreateVPCOfferingParams) SetSupportedservices(v []string) {
@@ -693,7 +666,6 @@ func (p *CreateVPCOfferingParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVPCOfferingParams instance,
@@ -798,7 +770,6 @@ func (p *DeletePrivateGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeletePrivateGatewayParams instance,
@@ -867,7 +838,6 @@ func (p *DeleteStaticRouteParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteStaticRouteParams instance,
@@ -936,7 +906,6 @@ func (p *DeleteVPCParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVPCParams instance,
@@ -1005,7 +974,6 @@ func (p *DeleteVPCOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVPCOfferingParams instance,
@@ -1114,7 +1082,6 @@ func (p *ListPrivateGatewaysParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetDomainid(v string) {
@@ -1122,7 +1089,6 @@ func (p *ListPrivateGatewaysParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetId(v string) {
@@ -1130,7 +1096,6 @@ func (p *ListPrivateGatewaysParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetIpaddress(v string) {
@@ -1138,7 +1103,6 @@ func (p *ListPrivateGatewaysParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetIsrecursive(v bool) {
@@ -1146,7 +1110,6 @@ func (p *ListPrivateGatewaysParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetKeyword(v string) {
@@ -1154,7 +1117,6 @@ func (p *ListPrivateGatewaysParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetListall(v bool) {
@@ -1162,7 +1124,6 @@ func (p *ListPrivateGatewaysParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetPage(v int) {
@@ -1170,7 +1131,6 @@ func (p *ListPrivateGatewaysParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetPagesize(v int) {
@@ -1178,7 +1138,6 @@ func (p *ListPrivateGatewaysParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetProjectid(v string) {
@@ -1186,7 +1145,6 @@ func (p *ListPrivateGatewaysParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetState(v string) {
@@ -1194,7 +1152,6 @@ func (p *ListPrivateGatewaysParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetVlan(v string) {
@@ -1202,7 +1159,6 @@ func (p *ListPrivateGatewaysParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
-	return
 }
 
 func (p *ListPrivateGatewaysParams) SetVpcid(v string) {
@@ -1210,7 +1166,6 @@ func (p *ListPrivateGatewaysParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new ListPrivateGatewaysParams instance,
@@ -1357,7 +1312,6 @@ func (p *ListStaticRoutesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetDomainid(v string) {
@@ -1365,7 +1319,6 @@ func (p *ListStaticRoutesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetGatewayid(v string) {
@@ -1373,7 +1326,6 @@ func (p *ListStaticRoutesParams) SetGatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gatewayid"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetId(v string) {
@@ -1381,7 +1333,6 @@ func (p *ListStaticRoutesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetIsrecursive(v bool) {
@@ -1389,7 +1340,6 @@ func (p *ListStaticRoutesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetKeyword(v string) {
@@ -1397,7 +1347,6 @@ func (p *ListStaticRoutesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetListall(v bool) {
@@ -1405,7 +1354,6 @@ func (p *ListStaticRoutesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetPage(v int) {
@@ -1413,7 +1361,6 @@ func (p *ListStaticRoutesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetPagesize(v int) {
@@ -1421,7 +1368,6 @@ func (p *ListStaticRoutesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetProjectid(v string) {
@@ -1429,7 +1375,6 @@ func (p *ListStaticRoutesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetTags(v map[string]string) {
@@ -1437,7 +1382,6 @@ func (p *ListStaticRoutesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListStaticRoutesParams) SetVpcid(v string) {
@@ -1445,7 +1389,6 @@ func (p *ListStaticRoutesParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new ListStaticRoutesParams instance,
@@ -1573,7 +1516,6 @@ func (p *ListVPCOfferingsParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetId(v string) {
@@ -1581,7 +1523,6 @@ func (p *ListVPCOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetIsdefault(v bool) {
@@ -1589,7 +1530,6 @@ func (p *ListVPCOfferingsParams) SetIsdefault(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdefault"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetKeyword(v string) {
@@ -1597,7 +1537,6 @@ func (p *ListVPCOfferingsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetName(v string) {
@@ -1605,7 +1544,6 @@ func (p *ListVPCOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetPage(v int) {
@@ -1613,7 +1551,6 @@ func (p *ListVPCOfferingsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetPagesize(v int) {
@@ -1621,7 +1558,6 @@ func (p *ListVPCOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetState(v string) {
@@ -1629,7 +1565,6 @@ func (p *ListVPCOfferingsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListVPCOfferingsParams) SetSupportedservices(v []string) {
@@ -1637,7 +1572,6 @@ func (p *ListVPCOfferingsParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
-	return
 }
 
 // You should always use this function to get a new ListVPCOfferingsParams instance,
@@ -1872,7 +1806,6 @@ func (p *ListVPCsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetCidr(v string) {
@@ -1880,7 +1813,6 @@ func (p *ListVPCsParams) SetCidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidr"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetDisplaytext(v string) {
@@ -1888,7 +1820,6 @@ func (p *ListVPCsParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetDomainid(v string) {
@@ -1896,7 +1827,6 @@ func (p *ListVPCsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetFordisplay(v bool) {
@@ -1904,7 +1834,6 @@ func (p *ListVPCsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetId(v string) {
@@ -1912,7 +1841,6 @@ func (p *ListVPCsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetIsrecursive(v bool) {
@@ -1920,7 +1848,6 @@ func (p *ListVPCsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetKeyword(v string) {
@@ -1928,7 +1855,6 @@ func (p *ListVPCsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetListall(v bool) {
@@ -1936,7 +1862,6 @@ func (p *ListVPCsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetName(v string) {
@@ -1944,7 +1869,6 @@ func (p *ListVPCsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetPage(v int) {
@@ -1952,7 +1876,6 @@ func (p *ListVPCsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetPagesize(v int) {
@@ -1960,7 +1883,6 @@ func (p *ListVPCsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetProjectid(v string) {
@@ -1968,7 +1890,6 @@ func (p *ListVPCsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetRestartrequired(v bool) {
@@ -1976,7 +1897,6 @@ func (p *ListVPCsParams) SetRestartrequired(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["restartrequired"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetState(v string) {
@@ -1984,7 +1904,6 @@ func (p *ListVPCsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetSupportedservices(v []string) {
@@ -1992,7 +1911,6 @@ func (p *ListVPCsParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetTags(v map[string]string) {
@@ -2000,7 +1918,6 @@ func (p *ListVPCsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetVpcofferingid(v string) {
@@ -2008,7 +1925,6 @@ func (p *ListVPCsParams) SetVpcofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcofferingid"] = v
-	return
 }
 
 func (p *ListVPCsParams) SetZoneid(v string) {
@@ -2016,7 +1932,6 @@ func (p *ListVPCsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVPCsParams instance,
@@ -2283,7 +2198,6 @@ func (p *RestartVPCParams) SetCleanup(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanup"] = v
-	return
 }
 
 func (p *RestartVPCParams) SetId(v string) {
@@ -2291,7 +2205,6 @@ func (p *RestartVPCParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *RestartVPCParams) SetMakeredundant(v bool) {
@@ -2299,7 +2212,6 @@ func (p *RestartVPCParams) SetMakeredundant(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["makeredundant"] = v
-	return
 }
 
 // You should always use this function to get a new RestartVPCParams instance,
@@ -2504,7 +2416,6 @@ func (p *UpdateVPCParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateVPCParams) SetDisplaytext(v string) {
@@ -2512,7 +2423,6 @@ func (p *UpdateVPCParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateVPCParams) SetFordisplay(v bool) {
@@ -2520,7 +2430,6 @@ func (p *UpdateVPCParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateVPCParams) SetId(v string) {
@@ -2528,7 +2437,6 @@ func (p *UpdateVPCParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateVPCParams) SetName(v string) {
@@ -2536,7 +2444,6 @@ func (p *UpdateVPCParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVPCParams instance,
@@ -2737,7 +2644,6 @@ func (p *UpdateVPCOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
-	return
 }
 
 func (p *UpdateVPCOfferingParams) SetId(v string) {
@@ -2745,7 +2651,6 @@ func (p *UpdateVPCOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateVPCOfferingParams) SetName(v string) {
@@ -2753,7 +2658,6 @@ func (p *UpdateVPCOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateVPCOfferingParams) SetState(v string) {
@@ -2761,7 +2665,6 @@ func (p *UpdateVPCOfferingParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVPCOfferingParams instance,

--- a/cloudstack/VPNService.go
+++ b/cloudstack/VPNService.go
@@ -56,7 +56,6 @@ func (p *AddVpnUserParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AddVpnUserParams) SetDomainid(v string) {
@@ -64,7 +63,6 @@ func (p *AddVpnUserParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *AddVpnUserParams) SetPassword(v string) {
@@ -72,7 +70,6 @@ func (p *AddVpnUserParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
-	return
 }
 
 func (p *AddVpnUserParams) SetProjectid(v string) {
@@ -80,7 +77,6 @@ func (p *AddVpnUserParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *AddVpnUserParams) SetUsername(v string) {
@@ -88,7 +84,6 @@ func (p *AddVpnUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new AddVpnUserParams instance,
@@ -186,7 +181,6 @@ func (p *CreateRemoteAccessVpnParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateRemoteAccessVpnParams) SetDomainid(v string) {
@@ -194,7 +188,6 @@ func (p *CreateRemoteAccessVpnParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateRemoteAccessVpnParams) SetFordisplay(v bool) {
@@ -202,7 +195,6 @@ func (p *CreateRemoteAccessVpnParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateRemoteAccessVpnParams) SetIprange(v string) {
@@ -210,7 +202,6 @@ func (p *CreateRemoteAccessVpnParams) SetIprange(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iprange"] = v
-	return
 }
 
 func (p *CreateRemoteAccessVpnParams) SetOpenfirewall(v bool) {
@@ -218,7 +209,6 @@ func (p *CreateRemoteAccessVpnParams) SetOpenfirewall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["openfirewall"] = v
-	return
 }
 
 func (p *CreateRemoteAccessVpnParams) SetPublicipid(v string) {
@@ -226,7 +216,6 @@ func (p *CreateRemoteAccessVpnParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateRemoteAccessVpnParams instance,
@@ -321,7 +310,6 @@ func (p *CreateVpnConnectionParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateVpnConnectionParams) SetPassive(v bool) {
@@ -329,7 +317,6 @@ func (p *CreateVpnConnectionParams) SetPassive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passive"] = v
-	return
 }
 
 func (p *CreateVpnConnectionParams) SetS2scustomergatewayid(v string) {
@@ -337,7 +324,6 @@ func (p *CreateVpnConnectionParams) SetS2scustomergatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["s2scustomergatewayid"] = v
-	return
 }
 
 func (p *CreateVpnConnectionParams) SetS2svpngatewayid(v string) {
@@ -345,7 +331,6 @@ func (p *CreateVpnConnectionParams) SetS2svpngatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["s2svpngatewayid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVpnConnectionParams instance,
@@ -481,7 +466,6 @@ func (p *CreateVpnCustomerGatewayParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetCidrlist(v string) {
@@ -489,7 +473,6 @@ func (p *CreateVpnCustomerGatewayParams) SetCidrlist(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetDomainid(v string) {
@@ -497,7 +480,6 @@ func (p *CreateVpnCustomerGatewayParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetDpd(v bool) {
@@ -505,7 +487,6 @@ func (p *CreateVpnCustomerGatewayParams) SetDpd(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dpd"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
@@ -513,7 +494,6 @@ func (p *CreateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["esplifetime"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetEsppolicy(v string) {
@@ -521,7 +501,6 @@ func (p *CreateVpnCustomerGatewayParams) SetEsppolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["esppolicy"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetForceencap(v bool) {
@@ -529,7 +508,6 @@ func (p *CreateVpnCustomerGatewayParams) SetForceencap(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forceencap"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetGateway(v string) {
@@ -537,7 +515,6 @@ func (p *CreateVpnCustomerGatewayParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
@@ -545,7 +522,6 @@ func (p *CreateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikelifetime"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetIkepolicy(v string) {
@@ -553,7 +529,6 @@ func (p *CreateVpnCustomerGatewayParams) SetIkepolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikepolicy"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
@@ -561,7 +536,6 @@ func (p *CreateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipsecpsk"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetName(v string) {
@@ -569,7 +543,6 @@ func (p *CreateVpnCustomerGatewayParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateVpnCustomerGatewayParams) SetProjectid(v string) {
@@ -577,7 +550,6 @@ func (p *CreateVpnCustomerGatewayParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVpnCustomerGatewayParams instance,
@@ -675,7 +647,6 @@ func (p *CreateVpnGatewayParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *CreateVpnGatewayParams) SetVpcid(v string) {
@@ -683,7 +654,6 @@ func (p *CreateVpnGatewayParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVpnGatewayParams instance,
@@ -765,7 +735,6 @@ func (p *DeleteRemoteAccessVpnParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteRemoteAccessVpnParams instance,
@@ -834,7 +803,6 @@ func (p *DeleteVpnConnectionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVpnConnectionParams instance,
@@ -903,7 +871,6 @@ func (p *DeleteVpnCustomerGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVpnCustomerGatewayParams instance,
@@ -972,7 +939,6 @@ func (p *DeleteVpnGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVpnGatewayParams instance,
@@ -1079,7 +1045,6 @@ func (p *ListRemoteAccessVpnsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetDomainid(v string) {
@@ -1087,7 +1052,6 @@ func (p *ListRemoteAccessVpnsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetFordisplay(v bool) {
@@ -1095,7 +1059,6 @@ func (p *ListRemoteAccessVpnsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetId(v string) {
@@ -1103,7 +1066,6 @@ func (p *ListRemoteAccessVpnsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetIsrecursive(v bool) {
@@ -1111,7 +1073,6 @@ func (p *ListRemoteAccessVpnsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetKeyword(v string) {
@@ -1119,7 +1080,6 @@ func (p *ListRemoteAccessVpnsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetListall(v bool) {
@@ -1127,7 +1087,6 @@ func (p *ListRemoteAccessVpnsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetNetworkid(v string) {
@@ -1135,7 +1094,6 @@ func (p *ListRemoteAccessVpnsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetPage(v int) {
@@ -1143,7 +1101,6 @@ func (p *ListRemoteAccessVpnsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetPagesize(v int) {
@@ -1151,7 +1108,6 @@ func (p *ListRemoteAccessVpnsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetProjectid(v string) {
@@ -1159,7 +1115,6 @@ func (p *ListRemoteAccessVpnsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListRemoteAccessVpnsParams) SetPublicipid(v string) {
@@ -1167,7 +1122,6 @@ func (p *ListRemoteAccessVpnsParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
-	return
 }
 
 // You should always use this function to get a new ListRemoteAccessVpnsParams instance,
@@ -1303,7 +1257,6 @@ func (p *ListVpnConnectionsParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetDomainid(v string) {
@@ -1311,7 +1264,6 @@ func (p *ListVpnConnectionsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetFordisplay(v bool) {
@@ -1319,7 +1271,6 @@ func (p *ListVpnConnectionsParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetId(v string) {
@@ -1327,7 +1278,6 @@ func (p *ListVpnConnectionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetIsrecursive(v bool) {
@@ -1335,7 +1285,6 @@ func (p *ListVpnConnectionsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetKeyword(v string) {
@@ -1343,7 +1292,6 @@ func (p *ListVpnConnectionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetListall(v bool) {
@@ -1351,7 +1299,6 @@ func (p *ListVpnConnectionsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetPage(v int) {
@@ -1359,7 +1306,6 @@ func (p *ListVpnConnectionsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetPagesize(v int) {
@@ -1367,7 +1313,6 @@ func (p *ListVpnConnectionsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetProjectid(v string) {
@@ -1375,7 +1320,6 @@ func (p *ListVpnConnectionsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVpnConnectionsParams) SetVpcid(v string) {
@@ -1383,7 +1327,6 @@ func (p *ListVpnConnectionsParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVpnConnectionsParams instance,
@@ -1523,7 +1466,6 @@ func (p *ListVpnCustomerGatewaysParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetDomainid(v string) {
@@ -1531,7 +1473,6 @@ func (p *ListVpnCustomerGatewaysParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetId(v string) {
@@ -1539,7 +1480,6 @@ func (p *ListVpnCustomerGatewaysParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetIsrecursive(v bool) {
@@ -1547,7 +1487,6 @@ func (p *ListVpnCustomerGatewaysParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetKeyword(v string) {
@@ -1555,7 +1494,6 @@ func (p *ListVpnCustomerGatewaysParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetListall(v bool) {
@@ -1563,7 +1501,6 @@ func (p *ListVpnCustomerGatewaysParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetPage(v int) {
@@ -1571,7 +1508,6 @@ func (p *ListVpnCustomerGatewaysParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetPagesize(v int) {
@@ -1579,7 +1515,6 @@ func (p *ListVpnCustomerGatewaysParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVpnCustomerGatewaysParams) SetProjectid(v string) {
@@ -1587,7 +1522,6 @@ func (p *ListVpnCustomerGatewaysParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVpnCustomerGatewaysParams instance,
@@ -1779,7 +1713,6 @@ func (p *ListVpnGatewaysParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetDomainid(v string) {
@@ -1787,7 +1720,6 @@ func (p *ListVpnGatewaysParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetFordisplay(v bool) {
@@ -1795,7 +1727,6 @@ func (p *ListVpnGatewaysParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetId(v string) {
@@ -1803,7 +1734,6 @@ func (p *ListVpnGatewaysParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetIsrecursive(v bool) {
@@ -1811,7 +1741,6 @@ func (p *ListVpnGatewaysParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetKeyword(v string) {
@@ -1819,7 +1748,6 @@ func (p *ListVpnGatewaysParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetListall(v bool) {
@@ -1827,7 +1755,6 @@ func (p *ListVpnGatewaysParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetPage(v int) {
@@ -1835,7 +1762,6 @@ func (p *ListVpnGatewaysParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetPagesize(v int) {
@@ -1843,7 +1769,6 @@ func (p *ListVpnGatewaysParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetProjectid(v string) {
@@ -1851,7 +1776,6 @@ func (p *ListVpnGatewaysParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVpnGatewaysParams) SetVpcid(v string) {
@@ -1859,7 +1783,6 @@ func (p *ListVpnGatewaysParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVpnGatewaysParams instance,
@@ -1989,7 +1912,6 @@ func (p *ListVpnUsersParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetDomainid(v string) {
@@ -1997,7 +1919,6 @@ func (p *ListVpnUsersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetId(v string) {
@@ -2005,7 +1926,6 @@ func (p *ListVpnUsersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetIsrecursive(v bool) {
@@ -2013,7 +1933,6 @@ func (p *ListVpnUsersParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetKeyword(v string) {
@@ -2021,7 +1940,6 @@ func (p *ListVpnUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetListall(v bool) {
@@ -2029,7 +1947,6 @@ func (p *ListVpnUsersParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetPage(v int) {
@@ -2037,7 +1954,6 @@ func (p *ListVpnUsersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetPagesize(v int) {
@@ -2045,7 +1961,6 @@ func (p *ListVpnUsersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetProjectid(v string) {
@@ -2053,7 +1968,6 @@ func (p *ListVpnUsersParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVpnUsersParams) SetUsername(v string) {
@@ -2061,7 +1975,6 @@ func (p *ListVpnUsersParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new ListVpnUsersParams instance,
@@ -2167,7 +2080,6 @@ func (p *RemoveVpnUserParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *RemoveVpnUserParams) SetDomainid(v string) {
@@ -2175,7 +2087,6 @@ func (p *RemoveVpnUserParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *RemoveVpnUserParams) SetProjectid(v string) {
@@ -2183,7 +2094,6 @@ func (p *RemoveVpnUserParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *RemoveVpnUserParams) SetUsername(v string) {
@@ -2191,7 +2101,6 @@ func (p *RemoveVpnUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveVpnUserParams instance,
@@ -2266,7 +2175,6 @@ func (p *ResetVpnConnectionParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ResetVpnConnectionParams) SetDomainid(v string) {
@@ -2274,7 +2182,6 @@ func (p *ResetVpnConnectionParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ResetVpnConnectionParams) SetId(v string) {
@@ -2282,7 +2189,6 @@ func (p *ResetVpnConnectionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ResetVpnConnectionParams instance,
@@ -2384,7 +2290,6 @@ func (p *UpdateRemoteAccessVpnParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateRemoteAccessVpnParams) SetFordisplay(v bool) {
@@ -2392,7 +2297,6 @@ func (p *UpdateRemoteAccessVpnParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateRemoteAccessVpnParams) SetId(v string) {
@@ -2400,7 +2304,6 @@ func (p *UpdateRemoteAccessVpnParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateRemoteAccessVpnParams instance,
@@ -2491,7 +2394,6 @@ func (p *UpdateVpnConnectionParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateVpnConnectionParams) SetFordisplay(v bool) {
@@ -2499,7 +2401,6 @@ func (p *UpdateVpnConnectionParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateVpnConnectionParams) SetId(v string) {
@@ -2507,7 +2408,6 @@ func (p *UpdateVpnConnectionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVpnConnectionParams instance,
@@ -2642,7 +2542,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetCidrlist(v string) {
@@ -2650,7 +2549,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetCidrlist(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetDomainid(v string) {
@@ -2658,7 +2556,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetDpd(v bool) {
@@ -2666,7 +2563,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetDpd(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dpd"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
@@ -2674,7 +2570,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["esplifetime"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetEsppolicy(v string) {
@@ -2682,7 +2577,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetEsppolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["esppolicy"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetForceencap(v bool) {
@@ -2690,7 +2584,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetForceencap(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forceencap"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetGateway(v string) {
@@ -2698,7 +2591,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetId(v string) {
@@ -2706,7 +2598,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
@@ -2714,7 +2605,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikelifetime"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetIkepolicy(v string) {
@@ -2722,7 +2612,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetIkepolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikepolicy"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
@@ -2730,7 +2619,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipsecpsk"] = v
-	return
 }
 
 func (p *UpdateVpnCustomerGatewayParams) SetName(v string) {
@@ -2738,7 +2626,6 @@ func (p *UpdateVpnCustomerGatewayParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVpnCustomerGatewayParams instance,
@@ -2840,7 +2727,6 @@ func (p *UpdateVpnGatewayParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateVpnGatewayParams) SetFordisplay(v bool) {
@@ -2848,7 +2734,6 @@ func (p *UpdateVpnGatewayParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
-	return
 }
 
 func (p *UpdateVpnGatewayParams) SetId(v string) {
@@ -2856,7 +2741,6 @@ func (p *UpdateVpnGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVpnGatewayParams instance,

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -60,7 +60,6 @@ func (p *AddNicToVirtualMachineParams) SetDhcpoptions(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpoptions"] = v
-	return
 }
 
 func (p *AddNicToVirtualMachineParams) SetIpaddress(v string) {
@@ -68,7 +67,6 @@ func (p *AddNicToVirtualMachineParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *AddNicToVirtualMachineParams) SetMacaddress(v string) {
@@ -76,7 +74,6 @@ func (p *AddNicToVirtualMachineParams) SetMacaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["macaddress"] = v
-	return
 }
 
 func (p *AddNicToVirtualMachineParams) SetNetworkid(v string) {
@@ -84,7 +81,6 @@ func (p *AddNicToVirtualMachineParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *AddNicToVirtualMachineParams) SetVirtualmachineid(v string) {
@@ -92,7 +88,6 @@ func (p *AddNicToVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new AddNicToVirtualMachineParams instance,
@@ -314,7 +309,6 @@ func (p *AssignVirtualMachineParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *AssignVirtualMachineParams) SetDomainid(v string) {
@@ -322,7 +316,6 @@ func (p *AssignVirtualMachineParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *AssignVirtualMachineParams) SetNetworkids(v []string) {
@@ -330,7 +323,6 @@ func (p *AssignVirtualMachineParams) SetNetworkids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkids"] = v
-	return
 }
 
 func (p *AssignVirtualMachineParams) SetProjectid(v string) {
@@ -338,7 +330,6 @@ func (p *AssignVirtualMachineParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *AssignVirtualMachineParams) SetSecuritygroupids(v []string) {
@@ -346,7 +337,6 @@ func (p *AssignVirtualMachineParams) SetSecuritygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupids"] = v
-	return
 }
 
 func (p *AssignVirtualMachineParams) SetVirtualmachineid(v string) {
@@ -354,7 +344,6 @@ func (p *AssignVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new AssignVirtualMachineParams instance,
@@ -547,7 +536,6 @@ func (p *ChangeServiceForVirtualMachineParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ChangeServiceForVirtualMachineParams) SetId(v string) {
@@ -555,7 +543,6 @@ func (p *ChangeServiceForVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ChangeServiceForVirtualMachineParams) SetServiceofferingid(v string) {
@@ -563,7 +550,6 @@ func (p *ChangeServiceForVirtualMachineParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 // You should always use this function to get a new ChangeServiceForVirtualMachineParams instance,
@@ -928,7 +914,6 @@ func (p *DeployVirtualMachineParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetAffinitygroupids(v []string) {
@@ -936,7 +921,6 @@ func (p *DeployVirtualMachineParams) SetAffinitygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupids"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetAffinitygroupnames(v []string) {
@@ -944,7 +928,6 @@ func (p *DeployVirtualMachineParams) SetAffinitygroupnames(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupnames"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetCustomid(v string) {
@@ -952,7 +935,6 @@ func (p *DeployVirtualMachineParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDatadiskofferinglist(v map[string]string) {
@@ -960,7 +942,6 @@ func (p *DeployVirtualMachineParams) SetDatadiskofferinglist(v map[string]string
 		p.p = make(map[string]interface{})
 	}
 	p.p["datadiskofferinglist"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDeploymentplanner(v string) {
@@ -968,7 +949,6 @@ func (p *DeployVirtualMachineParams) SetDeploymentplanner(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deploymentplanner"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDetails(v map[string]string) {
@@ -976,7 +956,6 @@ func (p *DeployVirtualMachineParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDhcpoptionsnetworklist(v map[string]string) {
@@ -984,7 +963,6 @@ func (p *DeployVirtualMachineParams) SetDhcpoptionsnetworklist(v map[string]stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpoptionsnetworklist"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDiskofferingid(v string) {
@@ -992,7 +970,6 @@ func (p *DeployVirtualMachineParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDisplayname(v string) {
@@ -1000,7 +977,6 @@ func (p *DeployVirtualMachineParams) SetDisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayname"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDisplayvm(v bool) {
@@ -1008,7 +984,6 @@ func (p *DeployVirtualMachineParams) SetDisplayvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvm"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetDomainid(v string) {
@@ -1016,7 +991,6 @@ func (p *DeployVirtualMachineParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetExtraconfig(v string) {
@@ -1024,7 +998,6 @@ func (p *DeployVirtualMachineParams) SetExtraconfig(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["extraconfig"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetGroup(v string) {
@@ -1032,7 +1005,6 @@ func (p *DeployVirtualMachineParams) SetGroup(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["group"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetHostid(v string) {
@@ -1040,7 +1012,6 @@ func (p *DeployVirtualMachineParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetHypervisor(v string) {
@@ -1048,7 +1019,6 @@ func (p *DeployVirtualMachineParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetIp6address(v string) {
@@ -1056,7 +1026,6 @@ func (p *DeployVirtualMachineParams) SetIp6address(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6address"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetIpaddress(v string) {
@@ -1064,7 +1033,6 @@ func (p *DeployVirtualMachineParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetIptonetworklist(v map[string]string) {
@@ -1072,7 +1040,6 @@ func (p *DeployVirtualMachineParams) SetIptonetworklist(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iptonetworklist"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetKeyboard(v string) {
@@ -1080,7 +1047,6 @@ func (p *DeployVirtualMachineParams) SetKeyboard(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyboard"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetKeypair(v string) {
@@ -1088,7 +1054,6 @@ func (p *DeployVirtualMachineParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetMacaddress(v string) {
@@ -1096,7 +1061,6 @@ func (p *DeployVirtualMachineParams) SetMacaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["macaddress"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetName(v string) {
@@ -1104,7 +1068,6 @@ func (p *DeployVirtualMachineParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetNetworkids(v []string) {
@@ -1112,7 +1075,6 @@ func (p *DeployVirtualMachineParams) SetNetworkids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkids"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetProjectid(v string) {
@@ -1120,7 +1082,6 @@ func (p *DeployVirtualMachineParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetRootdisksize(v int64) {
@@ -1128,7 +1089,6 @@ func (p *DeployVirtualMachineParams) SetRootdisksize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["rootdisksize"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetSecuritygroupids(v []string) {
@@ -1136,7 +1096,6 @@ func (p *DeployVirtualMachineParams) SetSecuritygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupids"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetSecuritygroupnames(v []string) {
@@ -1144,7 +1103,6 @@ func (p *DeployVirtualMachineParams) SetSecuritygroupnames(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupnames"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetServiceofferingid(v string) {
@@ -1152,7 +1110,6 @@ func (p *DeployVirtualMachineParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetSize(v int64) {
@@ -1160,7 +1117,6 @@ func (p *DeployVirtualMachineParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetStartvm(v bool) {
@@ -1168,7 +1124,6 @@ func (p *DeployVirtualMachineParams) SetStartvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startvm"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetTemplateid(v string) {
@@ -1176,7 +1131,6 @@ func (p *DeployVirtualMachineParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetUserdata(v string) {
@@ -1184,7 +1138,6 @@ func (p *DeployVirtualMachineParams) SetUserdata(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdata"] = v
-	return
 }
 
 func (p *DeployVirtualMachineParams) SetZoneid(v string) {
@@ -1192,7 +1145,6 @@ func (p *DeployVirtualMachineParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new DeployVirtualMachineParams instance,
@@ -1406,7 +1358,6 @@ func (p *DestroyVirtualMachineParams) SetExpunge(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["expunge"] = v
-	return
 }
 
 func (p *DestroyVirtualMachineParams) SetId(v string) {
@@ -1414,7 +1365,6 @@ func (p *DestroyVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DestroyVirtualMachineParams) SetVolumeids(v []string) {
@@ -1422,7 +1372,6 @@ func (p *DestroyVirtualMachineParams) SetVolumeids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeids"] = v
-	return
 }
 
 // You should always use this function to get a new DestroyVirtualMachineParams instance,
@@ -1626,7 +1575,6 @@ func (p *ExpungeVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ExpungeVirtualMachineParams instance,
@@ -1695,7 +1643,6 @@ func (p *GetVMPasswordParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new GetVMPasswordParams instance,
@@ -1847,7 +1794,6 @@ func (p *ListVirtualMachinesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetAffinitygroupid(v string) {
@@ -1855,7 +1801,6 @@ func (p *ListVirtualMachinesParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetDetails(v []string) {
@@ -1863,7 +1808,6 @@ func (p *ListVirtualMachinesParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetDisplayvm(v bool) {
@@ -1871,7 +1815,6 @@ func (p *ListVirtualMachinesParams) SetDisplayvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvm"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetDomainid(v string) {
@@ -1879,7 +1822,6 @@ func (p *ListVirtualMachinesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetForvirtualnetwork(v bool) {
@@ -1887,7 +1829,6 @@ func (p *ListVirtualMachinesParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetGroupid(v string) {
@@ -1895,7 +1836,6 @@ func (p *ListVirtualMachinesParams) SetGroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["groupid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetHostid(v string) {
@@ -1903,7 +1843,6 @@ func (p *ListVirtualMachinesParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetHypervisor(v string) {
@@ -1911,7 +1850,6 @@ func (p *ListVirtualMachinesParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetId(v string) {
@@ -1919,7 +1857,6 @@ func (p *ListVirtualMachinesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetIds(v []string) {
@@ -1927,7 +1864,6 @@ func (p *ListVirtualMachinesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetIsoid(v string) {
@@ -1935,7 +1871,6 @@ func (p *ListVirtualMachinesParams) SetIsoid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isoid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetIsrecursive(v bool) {
@@ -1943,7 +1878,6 @@ func (p *ListVirtualMachinesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetKeypair(v string) {
@@ -1951,7 +1885,6 @@ func (p *ListVirtualMachinesParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetKeyword(v string) {
@@ -1959,7 +1892,6 @@ func (p *ListVirtualMachinesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetListall(v bool) {
@@ -1967,7 +1899,6 @@ func (p *ListVirtualMachinesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetName(v string) {
@@ -1975,7 +1906,6 @@ func (p *ListVirtualMachinesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetNetworkid(v string) {
@@ -1983,7 +1913,6 @@ func (p *ListVirtualMachinesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetPage(v int) {
@@ -1991,7 +1920,6 @@ func (p *ListVirtualMachinesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetPagesize(v int) {
@@ -1999,7 +1927,6 @@ func (p *ListVirtualMachinesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetPodid(v string) {
@@ -2007,7 +1934,6 @@ func (p *ListVirtualMachinesParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetProjectid(v string) {
@@ -2015,7 +1941,6 @@ func (p *ListVirtualMachinesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetServiceofferingid(v string) {
@@ -2023,7 +1948,6 @@ func (p *ListVirtualMachinesParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetState(v string) {
@@ -2031,7 +1955,6 @@ func (p *ListVirtualMachinesParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetStorageid(v string) {
@@ -2039,7 +1962,6 @@ func (p *ListVirtualMachinesParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetTags(v map[string]string) {
@@ -2047,7 +1969,6 @@ func (p *ListVirtualMachinesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetTemplateid(v string) {
@@ -2055,7 +1976,6 @@ func (p *ListVirtualMachinesParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetUserid(v string) {
@@ -2063,7 +1983,6 @@ func (p *ListVirtualMachinesParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetVpcid(v string) {
@@ -2071,7 +1990,6 @@ func (p *ListVirtualMachinesParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
-	return
 }
 
 func (p *ListVirtualMachinesParams) SetZoneid(v string) {
@@ -2079,7 +1997,6 @@ func (p *ListVirtualMachinesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVirtualMachinesParams instance,
@@ -2356,7 +2273,6 @@ func (p *MigrateVirtualMachineParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *MigrateVirtualMachineParams) SetStorageid(v string) {
@@ -2364,7 +2280,6 @@ func (p *MigrateVirtualMachineParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *MigrateVirtualMachineParams) SetVirtualmachineid(v string) {
@@ -2372,7 +2287,6 @@ func (p *MigrateVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new MigrateVirtualMachineParams instance,
@@ -2586,7 +2500,6 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *MigrateVirtualMachineWithVolumeParams) SetMigrateto(v map[string]string) {
@@ -2594,7 +2507,6 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetMigrateto(v map[string]string
 		p.p = make(map[string]interface{})
 	}
 	p.p["migrateto"] = v
-	return
 }
 
 func (p *MigrateVirtualMachineWithVolumeParams) SetVirtualmachineid(v string) {
@@ -2602,7 +2514,6 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new MigrateVirtualMachineWithVolumeParams instance,
@@ -2807,7 +2718,6 @@ func (p *RebootVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RebootVirtualMachineParams instance,
@@ -3011,7 +2921,6 @@ func (p *RecoverVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new RecoverVirtualMachineParams instance,
@@ -3198,7 +3107,6 @@ func (p *RemoveNicFromVirtualMachineParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
-	return
 }
 
 func (p *RemoveNicFromVirtualMachineParams) SetVirtualmachineid(v string) {
@@ -3206,7 +3114,6 @@ func (p *RemoveNicFromVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new RemoveNicFromVirtualMachineParams instance,
@@ -3411,7 +3318,6 @@ func (p *ResetPasswordForVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new ResetPasswordForVirtualMachineParams instance,
@@ -3618,7 +3524,6 @@ func (p *RestoreVirtualMachineParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
-	return
 }
 
 func (p *RestoreVirtualMachineParams) SetVirtualmachineid(v string) {
@@ -3626,7 +3531,6 @@ func (p *RestoreVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new RestoreVirtualMachineParams instance,
@@ -3839,7 +3743,6 @@ func (p *ScaleVirtualMachineParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *ScaleVirtualMachineParams) SetId(v string) {
@@ -3847,7 +3750,6 @@ func (p *ScaleVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ScaleVirtualMachineParams) SetServiceofferingid(v string) {
@@ -3855,7 +3757,6 @@ func (p *ScaleVirtualMachineParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
-	return
 }
 
 // You should always use this function to get a new ScaleVirtualMachineParams instance,
@@ -3931,7 +3832,6 @@ func (p *StartVirtualMachineParams) SetDeploymentplanner(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deploymentplanner"] = v
-	return
 }
 
 func (p *StartVirtualMachineParams) SetHostid(v string) {
@@ -3939,7 +3839,6 @@ func (p *StartVirtualMachineParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *StartVirtualMachineParams) SetId(v string) {
@@ -3947,7 +3846,6 @@ func (p *StartVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StartVirtualMachineParams instance,
@@ -4155,7 +4053,6 @@ func (p *StopVirtualMachineParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
-	return
 }
 
 func (p *StopVirtualMachineParams) SetId(v string) {
@@ -4163,7 +4060,6 @@ func (p *StopVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new StopVirtualMachineParams instance,
@@ -4370,7 +4266,6 @@ func (p *UpdateDefaultNicForVirtualMachineParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
-	return
 }
 
 func (p *UpdateDefaultNicForVirtualMachineParams) SetVirtualmachineid(v string) {
@@ -4378,7 +4273,6 @@ func (p *UpdateDefaultNicForVirtualMachineParams) SetVirtualmachineid(v string) 
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateDefaultNicForVirtualMachineParams instance,
@@ -4644,7 +4538,6 @@ func (p *UpdateVirtualMachineParams) SetCleanupdetails(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanupdetails"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetCustomid(v string) {
@@ -4652,7 +4545,6 @@ func (p *UpdateVirtualMachineParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetDetails(v map[string]string) {
@@ -4660,7 +4552,6 @@ func (p *UpdateVirtualMachineParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetDhcpoptionsnetworklist(v map[string]string) {
@@ -4668,7 +4559,6 @@ func (p *UpdateVirtualMachineParams) SetDhcpoptionsnetworklist(v map[string]stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpoptionsnetworklist"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetDisplayname(v string) {
@@ -4676,7 +4566,6 @@ func (p *UpdateVirtualMachineParams) SetDisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayname"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetDisplayvm(v bool) {
@@ -4684,7 +4573,6 @@ func (p *UpdateVirtualMachineParams) SetDisplayvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvm"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetExtraconfig(v string) {
@@ -4692,7 +4580,6 @@ func (p *UpdateVirtualMachineParams) SetExtraconfig(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["extraconfig"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetGroup(v string) {
@@ -4700,7 +4587,6 @@ func (p *UpdateVirtualMachineParams) SetGroup(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["group"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetHaenable(v bool) {
@@ -4708,7 +4594,6 @@ func (p *UpdateVirtualMachineParams) SetHaenable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["haenable"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetId(v string) {
@@ -4716,7 +4601,6 @@ func (p *UpdateVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetInstancename(v string) {
@@ -4724,7 +4608,6 @@ func (p *UpdateVirtualMachineParams) SetInstancename(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["instancename"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetIsdynamicallyscalable(v bool) {
@@ -4732,7 +4615,6 @@ func (p *UpdateVirtualMachineParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetName(v string) {
@@ -4740,7 +4622,6 @@ func (p *UpdateVirtualMachineParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetOstypeid(v string) {
@@ -4748,7 +4629,6 @@ func (p *UpdateVirtualMachineParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetSecuritygroupids(v []string) {
@@ -4756,7 +4636,6 @@ func (p *UpdateVirtualMachineParams) SetSecuritygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupids"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetSecuritygroupnames(v []string) {
@@ -4764,7 +4643,6 @@ func (p *UpdateVirtualMachineParams) SetSecuritygroupnames(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupnames"] = v
-	return
 }
 
 func (p *UpdateVirtualMachineParams) SetUserdata(v string) {
@@ -4772,7 +4650,6 @@ func (p *UpdateVirtualMachineParams) SetUserdata(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdata"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVirtualMachineParams instance,

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -51,7 +51,6 @@ func (p *AttachVolumeParams) SetDeviceid(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deviceid"] = v
-	return
 }
 
 func (p *AttachVolumeParams) SetId(v string) {
@@ -59,7 +58,6 @@ func (p *AttachVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *AttachVolumeParams) SetVirtualmachineid(v string) {
@@ -67,7 +65,6 @@ func (p *AttachVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new AttachVolumeParams instance,
@@ -238,7 +235,6 @@ func (p *CreateVolumeParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetCustomid(v string) {
@@ -246,7 +242,6 @@ func (p *CreateVolumeParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetDiskofferingid(v string) {
@@ -254,7 +249,6 @@ func (p *CreateVolumeParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetDisplayvolume(v bool) {
@@ -262,7 +256,6 @@ func (p *CreateVolumeParams) SetDisplayvolume(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvolume"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetDomainid(v string) {
@@ -270,7 +263,6 @@ func (p *CreateVolumeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetMaxiops(v int64) {
@@ -278,7 +270,6 @@ func (p *CreateVolumeParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetMiniops(v int64) {
@@ -286,7 +277,6 @@ func (p *CreateVolumeParams) SetMiniops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["miniops"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetName(v string) {
@@ -294,7 +284,6 @@ func (p *CreateVolumeParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetProjectid(v string) {
@@ -302,7 +291,6 @@ func (p *CreateVolumeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetSize(v int64) {
@@ -310,7 +298,6 @@ func (p *CreateVolumeParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetSnapshotid(v string) {
@@ -318,7 +305,6 @@ func (p *CreateVolumeParams) SetSnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshotid"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetVirtualmachineid(v string) {
@@ -326,7 +312,6 @@ func (p *CreateVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *CreateVolumeParams) SetZoneid(v string) {
@@ -334,7 +319,6 @@ func (p *CreateVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new CreateVolumeParams instance,
@@ -463,7 +447,6 @@ func (p *DeleteVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteVolumeParams instance,
@@ -551,7 +534,6 @@ func (p *DetachVolumeParams) SetDeviceid(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deviceid"] = v
-	return
 }
 
 func (p *DetachVolumeParams) SetId(v string) {
@@ -559,7 +541,6 @@ func (p *DetachVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *DetachVolumeParams) SetVirtualmachineid(v string) {
@@ -567,7 +548,6 @@ func (p *DetachVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 // You should always use this function to get a new DetachVolumeParams instance,
@@ -705,7 +685,6 @@ func (p *ExtractVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ExtractVolumeParams) SetMode(v string) {
@@ -713,7 +692,6 @@ func (p *ExtractVolumeParams) SetMode(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mode"] = v
-	return
 }
 
 func (p *ExtractVolumeParams) SetUrl(v string) {
@@ -721,7 +699,6 @@ func (p *ExtractVolumeParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *ExtractVolumeParams) SetZoneid(v string) {
@@ -729,7 +706,6 @@ func (p *ExtractVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ExtractVolumeParams instance,
@@ -817,7 +793,6 @@ func (p *GetPathForVolumeParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new GetPathForVolumeParams instance,
@@ -870,7 +845,6 @@ func (p *GetSolidFireVolumeSizeParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new GetSolidFireVolumeSizeParams instance,
@@ -947,7 +921,6 @@ func (p *GetUploadParamsForVolumeParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetChecksum(v string) {
@@ -955,7 +928,6 @@ func (p *GetUploadParamsForVolumeParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetDiskofferingid(v string) {
@@ -963,7 +935,6 @@ func (p *GetUploadParamsForVolumeParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetDomainid(v string) {
@@ -971,7 +942,6 @@ func (p *GetUploadParamsForVolumeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetFormat(v string) {
@@ -979,7 +949,6 @@ func (p *GetUploadParamsForVolumeParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetImagestoreuuid(v string) {
@@ -987,7 +956,6 @@ func (p *GetUploadParamsForVolumeParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetName(v string) {
@@ -995,7 +963,6 @@ func (p *GetUploadParamsForVolumeParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetProjectid(v string) {
@@ -1003,7 +970,6 @@ func (p *GetUploadParamsForVolumeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *GetUploadParamsForVolumeParams) SetZoneid(v string) {
@@ -1011,7 +977,6 @@ func (p *GetUploadParamsForVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new GetUploadParamsForVolumeParams instance,
@@ -1070,7 +1035,6 @@ func (p *GetVolumeiScsiNameParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new GetVolumeiScsiNameParams instance,
@@ -1193,7 +1157,6 @@ func (p *ListVolumesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetClusterid(v string) {
@@ -1201,7 +1164,6 @@ func (p *ListVolumesParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetDiskofferingid(v string) {
@@ -1209,7 +1171,6 @@ func (p *ListVolumesParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetDisplayvolume(v bool) {
@@ -1217,7 +1178,6 @@ func (p *ListVolumesParams) SetDisplayvolume(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvolume"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetDomainid(v string) {
@@ -1225,7 +1185,6 @@ func (p *ListVolumesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetHostid(v string) {
@@ -1233,7 +1192,6 @@ func (p *ListVolumesParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetId(v string) {
@@ -1241,7 +1199,6 @@ func (p *ListVolumesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetIds(v []string) {
@@ -1249,7 +1206,6 @@ func (p *ListVolumesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetIsrecursive(v bool) {
@@ -1257,7 +1213,6 @@ func (p *ListVolumesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetKeyword(v string) {
@@ -1265,7 +1220,6 @@ func (p *ListVolumesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetListall(v bool) {
@@ -1273,7 +1227,6 @@ func (p *ListVolumesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetName(v string) {
@@ -1281,7 +1234,6 @@ func (p *ListVolumesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetPage(v int) {
@@ -1289,7 +1241,6 @@ func (p *ListVolumesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetPagesize(v int) {
@@ -1297,7 +1248,6 @@ func (p *ListVolumesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetPodid(v string) {
@@ -1305,7 +1255,6 @@ func (p *ListVolumesParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetProjectid(v string) {
@@ -1313,7 +1262,6 @@ func (p *ListVolumesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetStorageid(v string) {
@@ -1321,7 +1269,6 @@ func (p *ListVolumesParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetTags(v map[string]string) {
@@ -1329,7 +1276,6 @@ func (p *ListVolumesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetType(v string) {
@@ -1337,7 +1283,6 @@ func (p *ListVolumesParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetVirtualmachineid(v string) {
@@ -1345,7 +1290,6 @@ func (p *ListVolumesParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
-	return
 }
 
 func (p *ListVolumesParams) SetZoneid(v string) {
@@ -1353,7 +1297,6 @@ func (p *ListVolumesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListVolumesParams instance,
@@ -1560,7 +1503,6 @@ func (p *MigrateVolumeParams) SetLivemigrate(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["livemigrate"] = v
-	return
 }
 
 func (p *MigrateVolumeParams) SetNewdiskofferingid(v string) {
@@ -1568,7 +1510,6 @@ func (p *MigrateVolumeParams) SetNewdiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["newdiskofferingid"] = v
-	return
 }
 
 func (p *MigrateVolumeParams) SetStorageid(v string) {
@@ -1576,7 +1517,6 @@ func (p *MigrateVolumeParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 func (p *MigrateVolumeParams) SetVolumeid(v string) {
@@ -1584,7 +1524,6 @@ func (p *MigrateVolumeParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
-	return
 }
 
 // You should always use this function to get a new MigrateVolumeParams instance,
@@ -1734,7 +1673,6 @@ func (p *ResizeVolumeParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
-	return
 }
 
 func (p *ResizeVolumeParams) SetId(v string) {
@@ -1742,7 +1680,6 @@ func (p *ResizeVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ResizeVolumeParams) SetMaxiops(v int64) {
@@ -1750,7 +1687,6 @@ func (p *ResizeVolumeParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
-	return
 }
 
 func (p *ResizeVolumeParams) SetMiniops(v int64) {
@@ -1758,7 +1694,6 @@ func (p *ResizeVolumeParams) SetMiniops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["miniops"] = v
-	return
 }
 
 func (p *ResizeVolumeParams) SetShrinkok(v bool) {
@@ -1766,7 +1701,6 @@ func (p *ResizeVolumeParams) SetShrinkok(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["shrinkok"] = v
-	return
 }
 
 func (p *ResizeVolumeParams) SetSize(v int64) {
@@ -1774,7 +1708,6 @@ func (p *ResizeVolumeParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
-	return
 }
 
 // You should always use this function to get a new ResizeVolumeParams instance,
@@ -1923,7 +1856,6 @@ func (p *UpdateVolumeParams) SetChaininfo(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["chaininfo"] = v
-	return
 }
 
 func (p *UpdateVolumeParams) SetCustomid(v string) {
@@ -1931,7 +1863,6 @@ func (p *UpdateVolumeParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
-	return
 }
 
 func (p *UpdateVolumeParams) SetDisplayvolume(v bool) {
@@ -1939,7 +1870,6 @@ func (p *UpdateVolumeParams) SetDisplayvolume(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvolume"] = v
-	return
 }
 
 func (p *UpdateVolumeParams) SetId(v string) {
@@ -1947,7 +1877,6 @@ func (p *UpdateVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateVolumeParams) SetPath(v string) {
@@ -1955,7 +1884,6 @@ func (p *UpdateVolumeParams) SetPath(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["path"] = v
-	return
 }
 
 func (p *UpdateVolumeParams) SetState(v string) {
@@ -1963,7 +1891,6 @@ func (p *UpdateVolumeParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
-	return
 }
 
 func (p *UpdateVolumeParams) SetStorageid(v string) {
@@ -1971,7 +1898,6 @@ func (p *UpdateVolumeParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateVolumeParams instance,
@@ -2127,7 +2053,6 @@ func (p *UploadVolumeParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetChecksum(v string) {
@@ -2135,7 +2060,6 @@ func (p *UploadVolumeParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetDiskofferingid(v string) {
@@ -2143,7 +2067,6 @@ func (p *UploadVolumeParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetDomainid(v string) {
@@ -2151,7 +2074,6 @@ func (p *UploadVolumeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetFormat(v string) {
@@ -2159,7 +2081,6 @@ func (p *UploadVolumeParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetImagestoreuuid(v string) {
@@ -2167,7 +2088,6 @@ func (p *UploadVolumeParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetName(v string) {
@@ -2175,7 +2095,6 @@ func (p *UploadVolumeParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetProjectid(v string) {
@@ -2183,7 +2102,6 @@ func (p *UploadVolumeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetUrl(v string) {
@@ -2191,7 +2109,6 @@ func (p *UploadVolumeParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
-	return
 }
 
 func (p *UploadVolumeParams) SetZoneid(v string) {
@@ -2199,7 +2116,6 @@ func (p *UploadVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new UploadVolumeParams instance,

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -85,7 +85,6 @@ func (p *CreateZoneParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetDns1(v string) {
@@ -93,7 +92,6 @@ func (p *CreateZoneParams) SetDns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns1"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetDns2(v string) {
@@ -101,7 +99,6 @@ func (p *CreateZoneParams) SetDns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns2"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetDomain(v string) {
@@ -109,7 +106,6 @@ func (p *CreateZoneParams) SetDomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domain"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetDomainid(v string) {
@@ -117,7 +113,6 @@ func (p *CreateZoneParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetGuestcidraddress(v string) {
@@ -125,7 +120,6 @@ func (p *CreateZoneParams) SetGuestcidraddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestcidraddress"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetInternaldns1(v string) {
@@ -133,7 +127,6 @@ func (p *CreateZoneParams) SetInternaldns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internaldns1"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetInternaldns2(v string) {
@@ -141,7 +134,6 @@ func (p *CreateZoneParams) SetInternaldns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internaldns2"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetIp6dns1(v string) {
@@ -149,7 +141,6 @@ func (p *CreateZoneParams) SetIp6dns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns1"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetIp6dns2(v string) {
@@ -157,7 +148,6 @@ func (p *CreateZoneParams) SetIp6dns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns2"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetLocalstorageenabled(v bool) {
@@ -165,7 +155,6 @@ func (p *CreateZoneParams) SetLocalstorageenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["localstorageenabled"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetName(v string) {
@@ -173,7 +162,6 @@ func (p *CreateZoneParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetNetworktype(v string) {
@@ -181,7 +169,6 @@ func (p *CreateZoneParams) SetNetworktype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networktype"] = v
-	return
 }
 
 func (p *CreateZoneParams) SetSecuritygroupenabled(v bool) {
@@ -189,7 +176,6 @@ func (p *CreateZoneParams) SetSecuritygroupenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupenabled"] = v
-	return
 }
 
 // You should always use this function to get a new CreateZoneParams instance,
@@ -288,7 +274,6 @@ func (p *DedicateZoneParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *DedicateZoneParams) SetDomainid(v string) {
@@ -296,7 +281,6 @@ func (p *DedicateZoneParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *DedicateZoneParams) SetZoneid(v string) {
@@ -304,7 +288,6 @@ func (p *DedicateZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new DedicateZoneParams instance,
@@ -383,7 +366,6 @@ func (p *DeleteZoneParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 // You should always use this function to get a new DeleteZoneParams instance,
@@ -464,7 +446,6 @@ func (p *DisableOutOfBandManagementForZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new DisableOutOfBandManagementForZoneParams instance,
@@ -547,7 +528,6 @@ func (p *EnableOutOfBandManagementForZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new EnableOutOfBandManagementForZoneParams instance,
@@ -650,7 +630,6 @@ func (p *ListDedicatedZonesParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
-	return
 }
 
 func (p *ListDedicatedZonesParams) SetAffinitygroupid(v string) {
@@ -658,7 +637,6 @@ func (p *ListDedicatedZonesParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
-	return
 }
 
 func (p *ListDedicatedZonesParams) SetDomainid(v string) {
@@ -666,7 +644,6 @@ func (p *ListDedicatedZonesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListDedicatedZonesParams) SetKeyword(v string) {
@@ -674,7 +651,6 @@ func (p *ListDedicatedZonesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListDedicatedZonesParams) SetPage(v int) {
@@ -682,7 +658,6 @@ func (p *ListDedicatedZonesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListDedicatedZonesParams) SetPagesize(v int) {
@@ -690,7 +665,6 @@ func (p *ListDedicatedZonesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListDedicatedZonesParams) SetZoneid(v string) {
@@ -698,7 +672,6 @@ func (p *ListDedicatedZonesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ListDedicatedZonesParams instance,
@@ -795,7 +768,6 @@ func (p *ListZonesParams) SetAvailable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["available"] = v
-	return
 }
 
 func (p *ListZonesParams) SetDomainid(v string) {
@@ -803,7 +775,6 @@ func (p *ListZonesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
-	return
 }
 
 func (p *ListZonesParams) SetId(v string) {
@@ -811,7 +782,6 @@ func (p *ListZonesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *ListZonesParams) SetKeyword(v string) {
@@ -819,7 +789,6 @@ func (p *ListZonesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
-	return
 }
 
 func (p *ListZonesParams) SetName(v string) {
@@ -827,7 +796,6 @@ func (p *ListZonesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 func (p *ListZonesParams) SetNetworktype(v string) {
@@ -835,7 +803,6 @@ func (p *ListZonesParams) SetNetworktype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networktype"] = v
-	return
 }
 
 func (p *ListZonesParams) SetPage(v int) {
@@ -843,7 +810,6 @@ func (p *ListZonesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
-	return
 }
 
 func (p *ListZonesParams) SetPagesize(v int) {
@@ -851,7 +817,6 @@ func (p *ListZonesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
-	return
 }
 
 func (p *ListZonesParams) SetShowcapacities(v bool) {
@@ -859,7 +824,6 @@ func (p *ListZonesParams) SetShowcapacities(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showcapacities"] = v
-	return
 }
 
 func (p *ListZonesParams) SetTags(v map[string]string) {
@@ -867,7 +831,6 @@ func (p *ListZonesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
-	return
 }
 
 // You should always use this function to get a new ListZonesParams instance,
@@ -1044,7 +1007,6 @@ func (p *ReleaseDedicatedZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
-	return
 }
 
 // You should always use this function to get a new ReleaseDedicatedZoneParams instance,
@@ -1165,7 +1127,6 @@ func (p *UpdateZoneParams) SetAllocationstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocationstate"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetDetails(v map[string]string) {
@@ -1173,7 +1134,6 @@ func (p *UpdateZoneParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetDhcpprovider(v string) {
@@ -1181,7 +1141,6 @@ func (p *UpdateZoneParams) SetDhcpprovider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpprovider"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetDns1(v string) {
@@ -1189,7 +1148,6 @@ func (p *UpdateZoneParams) SetDns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns1"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetDns2(v string) {
@@ -1197,7 +1155,6 @@ func (p *UpdateZoneParams) SetDns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns2"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetDnssearchorder(v []string) {
@@ -1205,7 +1162,6 @@ func (p *UpdateZoneParams) SetDnssearchorder(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dnssearchorder"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetDomain(v string) {
@@ -1213,7 +1169,6 @@ func (p *UpdateZoneParams) SetDomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domain"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetGuestcidraddress(v string) {
@@ -1221,7 +1176,6 @@ func (p *UpdateZoneParams) SetGuestcidraddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestcidraddress"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetId(v string) {
@@ -1229,7 +1183,6 @@ func (p *UpdateZoneParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetInternaldns1(v string) {
@@ -1237,7 +1190,6 @@ func (p *UpdateZoneParams) SetInternaldns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internaldns1"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetInternaldns2(v string) {
@@ -1245,7 +1197,6 @@ func (p *UpdateZoneParams) SetInternaldns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internaldns2"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetIp6dns1(v string) {
@@ -1253,7 +1204,6 @@ func (p *UpdateZoneParams) SetIp6dns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns1"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetIp6dns2(v string) {
@@ -1261,7 +1211,6 @@ func (p *UpdateZoneParams) SetIp6dns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns2"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetIspublic(v bool) {
@@ -1269,7 +1218,6 @@ func (p *UpdateZoneParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetLocalstorageenabled(v bool) {
@@ -1277,7 +1225,6 @@ func (p *UpdateZoneParams) SetLocalstorageenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["localstorageenabled"] = v
-	return
 }
 
 func (p *UpdateZoneParams) SetName(v string) {
@@ -1285,7 +1232,6 @@ func (p *UpdateZoneParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
-	return
 }
 
 // You should always use this function to get a new UpdateZoneParams instance,

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -434,7 +434,7 @@ func getSortedKeysFromMap(m map[string]string) (keys []string) {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	return
+	return keys
 }
 
 // WithAsyncTimeout takes a custom timeout to be used by the CloudStackClient

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1357,7 +1357,7 @@ func (s *service) generateResponseType(a *API) {
 	// If this is a 'list' response, we need an separate list struct. There seem to be other
 	// types of responses that also need a separate list struct, so checking on exact matches
 	// for those once.
-	if strings.HasPrefix(a.Name, "list") || a.Name == "registerTemplate" {
+	if strings.HasPrefix(a.Name, "list") && a.Name != "listCapabilities" || a.Name == "registerTemplate" {
 		pn("type %s struct {", tn)
 		pn("	Count int `json:\"count\"`")
 
@@ -1375,6 +1375,12 @@ func (s *service) generateResponseType(a *API) {
 		default:
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), strings.ToLower(parseSingular(ln)))
 		}
+		pn("}")
+		pn("")
+		tn = parseSingular(ln)
+	} else if a.Name == "listCapabilities" {
+		pn("type %s struct {", tn)
+		pn("    %s *%s `json:\"%s\"`", ln, parseSingular(ln), "capability")
 		pn("}")
 		pn("")
 		tn = parseSingular(ln)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -107,15 +107,17 @@ func (s services) Swap(i, j int) {
 // APIParams represents a list of API params
 type APIParams []*APIParam
 
-// Add functions for the Sort interface
+// Len implements the Sort interface
 func (s APIParams) Len() int {
 	return len(s)
 }
 
+// Less implements the Sort interface
 func (s APIParams) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
+// Swap implements the Sort interface
 func (s APIParams) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
@@ -148,15 +150,17 @@ type APIResponse struct {
 // APIResponses represents a list of API responses
 type APIResponses []*APIResponse
 
-// Add functions for the Sort interface
+// Len implements the Sort interface
 func (s APIResponses) Len() int {
 	return len(s)
 }
 
+// Less implements the Sort interface
 func (s APIResponses) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
+// Swap implements the Sort interface
 func (s APIResponses) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
@@ -192,7 +196,7 @@ func main() {
 	if len(errors) > 0 {
 		log.Printf("%d API(s) failed to generate:", len(errors))
 		for _, ce := range errors {
-			log.Printf(ce.Error())
+			log.Print(ce.Error())
 		}
 		os.Exit(1)
 	}
@@ -509,7 +513,7 @@ func (as *allServices) GeneralCode() ([]byte, error) {
 	pn("		keys = append(keys, k)")
 	pn("	}")
 	pn("	sort.Strings(keys)")
-	pn("	return")
+	pn("	return keys")
 	pn("}")
 	pn("")
 	pn("// WithAsyncTimeout takes a custom timeout to be used by the CloudStackClient")
@@ -829,7 +833,6 @@ func (s *service) GenerateCode() ([]byte, error) {
 		pn("		p.p = make(map[string]interface{})")
 		pn("	}")
 		pn("	p.p[param] = v")
-		pn("	return")
 		pn("}")
 		pn("")
 		pn("func (s *CustomService) CustomRequest(api string, p *CustomServiceParams, result interface{}) error {")
@@ -866,7 +869,6 @@ func (s *service) generateParamType(a *API) {
 	pn("type %s struct {", capitalize(a.Name+"Params"))
 	pn("	p map[string]interface{}")
 	pn("}\n")
-	return
 }
 
 func (s *service) generateToURLValuesFunc(a *API) {
@@ -885,7 +887,6 @@ func (s *service) generateToURLValuesFunc(a *API) {
 	pn("	return u")
 	pn("}")
 	pn("")
-	return
 }
 
 func (s *service) generateConvertCode(cmd, name, typ string) {
@@ -929,7 +930,6 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 		}
 		pn("}")
 	}
-	return
 }
 
 func (s *service) parseParamName(name string) string {
@@ -950,13 +950,11 @@ func (s *service) generateParamSettersFunc(a *API) {
 			pn("		p.p = make(map[string]interface{})")
 			pn("	}")
 			pn("	p.p[\"%s\"] = v", ap.Name)
-			pn("	return")
 			pn("}")
 			pn("")
 			found[ap.Name] = true
 		}
 	}
-	return
 }
 
 func (s *service) generateNewParamTypeFunc(a *API) {
@@ -986,7 +984,6 @@ func (s *service) generateNewParamTypeFunc(a *API) {
 	pn("	return p")
 	pn("}")
 	pn("")
-	return
 }
 
 func (s *service) generateHelperFuncs(a *API) {
@@ -1186,7 +1183,6 @@ func (s *service) generateHelperFuncs(a *API) {
 			pn("")
 		}
 	}
-	return
 }
 
 func hasNameOrKeywordParamField(params APIParams) (v string, found bool) {
@@ -1357,30 +1353,30 @@ func (s *service) generateResponseType(a *API) {
 	// If this is a 'list' response, we need an separate list struct. There seem to be other
 	// types of responses that also need a separate list struct, so checking on exact matches
 	// for those once.
-	if strings.HasPrefix(a.Name, "list") && a.Name != "listCapabilities" || a.Name == "registerTemplate" {
+	if strings.HasPrefix(a.Name, "list") || a.Name == "registerTemplate" {
 		pn("type %s struct {", tn)
-		pn("	Count int `json:\"count\"`")
 
 		// This nasty check is for some specific response that do not behave consistent
 		switch a.Name {
 		case "listAsyncJobs":
+			pn("	Count int `json:\"count\"`")
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "asyncjobs")
+		case "listCapabilities":
+			pn("    %s *%s `json:\"%s\"`", ln, parseSingular(ln), "capability")
 		case "listEgressFirewallRules":
+			pn("	Count int `json:\"count\"`")
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "firewallrule")
 		case "listLoadBalancerRuleInstances":
+			pn("	Count int `json:\"count\"`")
 			pn("	LBRuleVMIDIPs []*%s `json:\"%s\"`", parseSingular(ln), "lbrulevmidip")
 			pn("	LoadBalancerRuleInstances []*VirtualMachine `json:\"%s\"`", strings.ToLower(parseSingular(ln)))
 		case "registerTemplate":
+			pn("	Count int `json:\"count\"`")
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "template")
 		default:
+			pn("	Count int `json:\"count\"`")
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), strings.ToLower(parseSingular(ln)))
 		}
-		pn("}")
-		pn("")
-		tn = parseSingular(ln)
-	} else if a.Name == "listCapabilities" {
-		pn("type %s struct {", tn)
-		pn("    %s *%s `json:\"%s\"`", ln, parseSingular(ln), "capability")
 		pn("}")
 		pn("")
 		tn = parseSingular(ln)


### PR DESCRIPTION
Different from other list commands, listcapabilities does not return an array list.

```
(localcloud) 🐱 > list capabilities
{
  "capability": {
    "allowusercreateprojects": true,
    "allowuserexpungerecovervm": true,
    "allowuserexpungerecovervolume": true,
    "allowuserviewalldomainaccounts": false,
    "allowuserviewdestroyedvm": true,
    "cloudstackversion": "4.15.0.0",
    "customdiskofferingmaxsize": 1024,
    "customdiskofferingminsize": 1,
    "dynamicrolesenabled": true,
    "kubernetesclusterexperimentalfeaturesenabled": false,
    "kubernetesserviceenabled": true,
    "kvmsnapshotenabled": true,
    "projectinviterequired": false,
    "regionsecondaryenabled": false,
    "securitygroupsenabled": false,
    "supportELB": "false",
    "userpublictemplateenabled": true
  }
}
```

for other list apis, e.g. list templates
```
(localcloud) 🐱 > list templates templatefilter=all filter=id,name
{
  "count": 2,
  "template": [
    {
      "id": "b54e8a17-ebe5-4849-a015-2698e1d01768",
      "name": "SystemVM Template (KVM)"
    },
    {
      "id": "63985306-48ee-11eb-8680-069fc4003392",
      "name": "CentOS 5.5(64-bit) no GUI (KVM)"
    }
  ]
}
```